### PR TITLE
Add CSG dependency to fix broken build

### DIFF
--- a/genie.lua
+++ b/genie.lua
@@ -339,8 +339,7 @@ includedirs {
     "external/manifold/src/sdf/include",
     "external/manifold/src/third_party/graphlite/include",
     "external/fuzzy-bools",
-    "external/fuzzy-bools/deps/cdt",
-    "external/csgjs-cpp"
+    "external/fuzzy-bools/deps/cdt"
 }
 
 excludes {


### PR DESCRIPTION
PR to add CSG.js dependency directory in order to gain access to missing header file that's preventing successful builds.