### PR TITLE
Changes required for AP214 end to end

### DIFF
--- a/conway_geometry/operations/mesh_utils.h
+++ b/conway_geometry/operations/mesh_utils.h
@@ -181,6 +181,10 @@ inline void TriangulateCylindricalSurface(IfcGeometry &geometry,
                                           IfcSurface &surface) {
   // First we get the cylinder data
 
+  if ( bounds.empty() ) {
+    return;
+  }
+
   double radius = surface.CylinderSurface.Radius;
   glm::dvec3 cent = surface.transformation[3];
   glm::dvec3 vecX = glm::normalize(surface.transformation[0]);
@@ -211,8 +215,8 @@ inline void TriangulateCylindricalSurface(IfcGeometry &geometry,
   }
 
   for (int r = 0; r < numRots; r++) {
-    std::vector<glm::dvec3> newList;
-    newPoints.push_back(newList);
+
+    newPoints.emplace_back();
   }
 
   std::vector<glm::dvec3> bounding;
@@ -222,6 +226,7 @@ inline void TriangulateCylindricalSurface(IfcGeometry &geometry,
   // Find the max. curve index in the boundary
 
   int maxTeam = 0;
+
   for (size_t i = 0; i < bounds.size(); i++) {
     for (size_t j = 0; j < bounds[i].curve.indices.size(); j++) {
       if (bounds[i].curve.indices[j] > maxTeam) {


### PR DESCRIPTION
These changes add a bounds check for a case that was failing in STEP AP214 and are a dependency for Conway's simple end-to-end STEP 214 changes (https://github.com/bldrs-ai/conway/pull/132) and is tied to the issue (https://github.com/bldrs-ai/conway/issues/130).