### PR TITLE
Fix for extrusioned area solid position transforms.

### DIFF
--- a/conway_geometry/representation/IfcGeometry.cpp
+++ b/conway_geometry/representation/IfcGeometry.cpp
@@ -300,6 +300,10 @@ void IfcGeometry::ApplyTransform(const glm::dmat4& transform) {
       std::swap( *indexPtr, indexPtr[ 2 ] );
     }
   }
+
+  for ( auto& localPart : part ) {
+    localPart.ApplyTransform( transform );
+  }
 }
 
 }  // namespace conway::geometry


### PR DESCRIPTION
This fix (the conway-geom part) makes for applied transforms (transforms being baked into the geometry) being recursively applied to parts.

It fixes the issue of the edges of the roof sticking upwards for https://github.com/bldrs-ai/test-models-private/issues/39