### PR TITLE
Clean-up of C++ issues for open-source release.

### DIFF
--- a/conway-api.cpp
+++ b/conway-api.cpp
@@ -13,12 +13,6 @@
 
 std::unique_ptr<conway::geometry::ConwayGeometryProcessor> processor;
 
-#ifdef __EMSCRIPTEN_PTHREADS__
-constexpr bool MT_ENABLED = true;
-#else
-constexpr bool MT_ENABLED = false;
-#endif
-
 // use to construct API placeholders
 int main() { return 0; }
 
@@ -141,6 +135,8 @@ conway::geometry::IfcGeometry GetPolygonalBoundedHalfspace(
     if (processor) {
       return processor->GetPolygonalBoundedHalfspace(parameters);
     }
+
+    return conway::geometry::IfcGeometry();
   }
 
 conway::geometry::IfcGeometry GetExtrudedAreaSolid(

--- a/conway_geometry/ConwayGeometryProcessor.cpp
+++ b/conway_geometry/ConwayGeometryProcessor.cpp
@@ -2,14 +2,20 @@
 
 #include <glm/glm.hpp>
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-variable"
+#pragma clang diagnostic ignored "-Wunused-but-set-variable"
+#pragma clang diagnostic ignored "-Wunused-function"
+#pragma clang diagnostic ignored "-Wunknown-pragmas"
+#pragma clang diagnostic ignored "-Wreturn-type"
 #include "fuzzy/fuzzy-bools.h"
-// #include "legacy/math/bool-mesh-mesh.h"
-// #include "legacy/math/intersect-mesh-mesh.h"
-#include "operations/curve-utils.h"
-#include "operations/geometryutils.h"
+#pragma clang diagnostic pop
+
+#include "operations/curve_utils.h"
+#include "operations/geometry_utils.h"
 #include "operations/mesh_utils.h"
 #include "representation/geometry.h"
-#include "../logging/Logger.h"
+#include "Logger.h"
 
 namespace conway::geometry {
 IfcComposedMesh ConwayGeometryProcessor::getMappedItem(
@@ -1034,13 +1040,10 @@ std::vector<IfcBound3D> ConwayGeometryProcessor::ReadIndexedPolygonalFace(
       bounds.emplace_back();
       size_t startIdx = parameters.face.face_starts[i];
       size_t endIdx = 0;
-      size_t faceVoidsSize = 0;
       if (i + 1 >= parameters.face.face_starts.size()) {
         endIdx = parameters.face.indices.size();
-        faceVoidsSize = endIdx - startIdx;
       } else {
         endIdx = parameters.face.face_starts[i + 1];
-        faceVoidsSize = endIdx - startIdx;
       }
 
       for (size_t index = startIdx; index < endIdx; index++) {
@@ -1052,8 +1055,6 @@ std::vector<IfcBound3D> ConwayGeometryProcessor::ReadIndexedPolygonalFace(
         bounds.back().curve.points.push_back(point);
       }
     }
-
-    ;
   }
 
   return bounds;
@@ -1102,6 +1103,10 @@ ConwayGeometryProcessor::GeometryToGltf(
         case BLEND_MODE::MASK:
 
           material.alphaMode = Microsoft::glTF::AlphaMode::ALPHA_MASK;
+          break;
+
+        default:
+
           break;
       }
 
@@ -1193,8 +1198,6 @@ ConwayGeometryProcessor::GeometryToGltf(
           dracoMeshCompression;
 
       int32_t pos_att_id = -1;
-      int32_t tex_att_id = -1;
-      int32_t material_att_id = -1;
 
       // this internally populates the vertex float array, current storage type
       // is double
@@ -1234,11 +1237,6 @@ ConwayGeometryProcessor::GeometryToGltf(
                   draco::DT_FLOAT32, false, sizeof(float) * 3, 0);
           pos_att_id = dracoMesh->AddAttribute(va, false, numPositions);
         }
-
-        // TODO(nickcastel50): support multiple materials at some point when we
-        // add that
-        int32_t numMaterials = 1;
-        int32_t numTexCoords = 0;
 
         // populate position attribute
 
@@ -1286,7 +1284,6 @@ ConwayGeometryProcessor::GeometryToGltf(
             const draco::PointIndex vert_id_0(compositeIndiceIndex);
             const draco::PointIndex vert_id_1(compositeIndiceIndex + 1);
             const draco::PointIndex vert_id_2(compositeIndiceIndex + 2);
-            const int triangulated_index = 0;
 
             // map vertex to face index
             dracoMesh->attribute(pos_att_id)
@@ -1410,8 +1407,6 @@ ConwayGeometryProcessor::GeometryToGltf(
 
       positions.resize(numPoints * 3);
       indexData.reserve(numIndices);
-
-      uint32_t numFaces = numIndices / 3;
 
       std::vector<float> minValues(3U, std::numeric_limits<float>::max());
       std::vector<float> maxValues(3U, std::numeric_limits<float>::lowest());
@@ -2156,7 +2151,6 @@ conway::geometry::IfcCurve ConwayGeometryProcessor::getIfcCircle(
       glm::dmat4 placement = parameters.axis2Placement3D;
       glm::dvec4 vecX = placement[0];
       glm::dvec4 vecY = placement[1];
-      glm::dvec4 vecZ = placement[2];
 
       glm::dvec3 v1 =
           glm::dvec3(parameters.paramsGetIfcTrimmedCurve.trim1Cartesian3D.x -
@@ -2227,7 +2221,6 @@ else
 }
 
 double startRad = degreesToRadians(startDegrees);
-double endRad = degreesToRadians(endDegrees);
 double lengthRad = degreesToRadians(lengthDegrees);
 
 size_t startIndex = curve.points.size();

--- a/conway_geometry/ConwayGeometryProcessor.h
+++ b/conway_geometry/ConwayGeometryProcessor.h
@@ -18,7 +18,14 @@
 #include <glm/glm.hpp>
 #include <glm/gtx/transform.hpp>
 #include <iostream>
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-variable"
+#pragma clang diagnostic ignored "-Wunused-but-set-variable"
+#pragma clang diagnostic ignored "-Wunused-function"
 #include <mapbox/earcut.hpp>
+#pragma clang diagnostic push
+
 #include <span>
 #include <sstream>
 #include <string>
@@ -47,7 +54,7 @@
 #include <GLTFSDK/IStreamWriter.h>
 #include <GLTFSDK/Serialize.h>
 
-#include "operations/geometryutils.h"
+#include "operations/geometry_utils.h"
 #include "representation/IfcGeometry.h"
 #include "representation/geometry.h"
 

--- a/conway_geometry/operations/curve_utils.h
+++ b/conway_geometry/operations/curve_utils.h
@@ -7,8 +7,8 @@
 
 #pragma once
 
-#include "../representation/ConwayCurve.h"
-#include "../../logging/Logger.h"
+#include "representation/ConwayCurve.h"
+#include "Logger.h"
 
 namespace conway::geometry {
 
@@ -27,9 +27,6 @@ inline IfcCurve Build3DArc3Pt(const glm::dvec3 &p1, const glm::dvec3 &p2,
   // Calculate the center of the circle
   glm::dvec3 v1 = p2 - p1;
   glm::dvec3 v2 = p3 - p1;
-  glm::dvec3 normal = glm::normalize(glm::cross(v1, v2));
-  glm::dvec3 mid1 = 0.5 * (p1 + p2);
-  glm::dvec3 mid2 = 0.5 * (p1 + p3);
   glm::dvec3 center;
 
   if (glm::length(glm::cross(v1, v2)) < EPS_MINSIZE) {
@@ -653,7 +650,6 @@ inline IfcCurve GetLShapedCurve(double width, double depth, double thickness,
 
   double hw = width / 2;
   double hd = depth / 2;
-  double hweb = thickness / 2;
 
   c.points.push_back(placement * glm::dvec3(-hw, +hd, 1));
   c.points.push_back(placement * glm::dvec3(-hw, -hd, 1));

--- a/conway_geometry/operations/geometry_utils.h
+++ b/conway_geometry/operations/geometry_utils.h
@@ -7,7 +7,12 @@
 
 #pragma once
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-variable"
+#pragma clang diagnostic ignored "-Wunused-but-set-variable"
+#pragma clang diagnostic ignored "-Wunused-function"
 #include <mapbox/earcut.hpp>
+#pragma clang diagnostic pop
 
 #include "../../utility/LoaderError.h"
 #include "../representation/IfcGeometry.h"
@@ -253,9 +258,6 @@ inline IfcGeometry Sweep(
     // connect the curves
     for (size_t i = 1; i < dpts.size(); i++)
     {
-      glm::dvec3 p1 = dpts[i - 1];
-      glm::dvec3 p2 = dpts[i];
-
       const auto &c1 = curves[i - 1].points;
       const auto &c2 = curves[i].points;
 
@@ -546,8 +548,6 @@ inline bool GetBasisFromCoplanarPoints(std::vector<glm::dvec3> &points,
       distanceSqr = candidate2;
     }
   }
-
-  glm::dvec3 normal;
 
   double bestArea = 0;
 
@@ -946,8 +946,6 @@ inline std::optional<glm::dvec3> GetOriginRec(
     IfcComposedMesh &mesh,
     std::unordered_map<uint32_t, IfcGeometry> &geometryMap, glm::dmat4 mat) {
   glm::dmat4 newMat = mat * mesh.transformation;
-
-  bool transformationBreaksWinding = MatrixFlipsTriangles(newMat);
 
   auto geomIt = geometryMap.find(mesh.expressID);
 

--- a/conway_geometry/operations/mesh_utils.h
+++ b/conway_geometry/operations/mesh_utils.h
@@ -15,7 +15,7 @@
 #include <unordered_map>
 #include <vector>
 
-#include "geometryutils.h"
+#include "geometry_utils.h"
 #include "tesselation_utils.h"
 
 #define CONST_PI 3.141592653589793238462643383279502884L

--- a/conway_geometry/operations/tesselation_utils.h
+++ b/conway_geometry/operations/tesselation_utils.h
@@ -3,9 +3,9 @@
 #include <cmath>
 #include <glm/glm.hpp>
 
-#include "../representation/winged_edge.h"
+#include "winged_edge.h"
 #include <queue>
-#include "../representation/IfcGeometry.h"
+#include "representation/IfcGeometry.h"
 
 namespace conway::geometry {
 

--- a/conway_geometry/operations/winged_edge.h
+++ b/conway_geometry/operations/winged_edge.h
@@ -3,7 +3,7 @@
 #include <stdint.h>
 #include <vector>
 #include <unordered_map>
-#include "IfcGeometry.h"
+#include "representation/IfcGeometry.h"
 
 namespace conway::geometry {
 
@@ -182,5 +182,4 @@ namespace conway::geometry {
       return mapIterator->second;
     }
   };
-
 }

--- a/conway_geometry/representation/ConwayProfile.cpp
+++ b/conway_geometry/representation/ConwayProfile.cpp
@@ -6,7 +6,7 @@
 #include <glm/glm.hpp>
 #include <vector>
 
-#include "../operations/geometryutils.h"
+#include "operations/geometry_utils.h"
 
 #include <sstream>
 #include "SVGContext.h"
@@ -29,7 +29,7 @@ std::string IfcProfile::DumpToOBJ( const std::string& preamble ) const {
 
   for ( const IfcCurve& hole : holes ) {
 
-    for ( const glm::dvec3& t : curve.points ) {
+    for ( const glm::dvec3& t : hole.points ) {
     
       obj << "v " << t.x << " " << t.y << " " << t.z << "\n";
     }

--- a/conway_geometry/representation/IfcGeometry.cpp
+++ b/conway_geometry/representation/IfcGeometry.cpp
@@ -300,8 +300,6 @@ void IfcGeometry::ApplyTransform(const glm::dmat4& transform) {
 
   if ( glm::determinant( transform ) < 0 ) {
 
-    uint32_t* indexPtr = indexData.data();
-
     for ( uint32_t* indexPtr = indexData.data(), 
                   * end = indexData.data() + indexData.size(); 
           indexPtr < end; 

--- a/conway_geometry/representation/IfcGeometry.h
+++ b/conway_geometry/representation/IfcGeometry.h
@@ -9,7 +9,13 @@
 
 #pragma once
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-variable"
+#pragma clang diagnostic ignored "-Wunused-function"
+
 #include <fuzzy/geometry.h>
+
+#pragma clang diagnostic pop
 
 #include <glm/glm.hpp>
 #include <optional>

--- a/conway_geometry/representation/SVGContext.h
+++ b/conway_geometry/representation/SVGContext.h
@@ -31,10 +31,12 @@ namespace conway::geometry {
 
     SVGContext& header() {
       stream << "<svg width=\"" << size.x << "\" height=\"" << size.y << " \" xmlns=\"http://www.w3.org/2000/svg\">";
+      return *this;
     }
 
     SVGContext& trailer() {
       stream << "</svg>";
+      return *this;
     }
 
     glm::dvec2 toSvg( const glm::dvec2& from ) const {

--- a/genie.lua
+++ b/genie.lua
@@ -86,6 +86,8 @@ project "conway_geom_native"
         }
 
         includedirs {
+            "conway_geometry",
+            "logging",
             "external/tinynurbs/include",
             "external/manifold/src",
             "external/manifold/src/utilities/include",
@@ -248,6 +250,8 @@ project "conway_geom_native_tests"
         }
 
         includedirs {
+            "conway_geometry",
+            "logging",
             "external/tinynurbs/include",
             "external/manifold/src",
             "external/manifold/src/utilities/include",
@@ -582,6 +586,8 @@ end
         }
 
         includedirs {
+            "conway_geometry",
+            "logging",
             "external/tinynurbs/include",
             "external/manifold/src",
             "external/manifold/src/utilities/include",
@@ -790,6 +796,8 @@ end
         }
 
         includedirs {
+            "conway_geometry",
+            "logging",
             "external/tinynurbs/include",
             "external/manifold/src",
             "external/manifold/src/utilities/include",


### PR DESCRIPTION
* Normalised naming and location of utils files and moved winged_edge to operations.
* Added extra include dirs to genie builds to enable removing of non standard relative paths in include '../'
* Removed non standard relative paths in includes.
* Used pragmas to isolate out warnings from 3rd party dependencies.
* Fixed warnings in the conway geometry code.