### PR TITLE
Disable GROWABLE_ARRAYBUFFERS (Emscripten 6.0.2 default broke Web APIs → see-through geometry)

### DIFF
--- a/genie.lua
+++ b/genie.lua
@@ -195,7 +195,7 @@ project "conway_geom_native"
             "--bind",
             "-03",
             "-flto",
-            '--define-macro=REAL_T_IS_DOUBLE -s ALLOW_MEMORY_GROWTH=1 -s MAXIMUM_MEMORY=4GB -s FORCE_FILESYSTEM=1 -s EXPORT_NAME=conway_geom_native -s MODULARIZE=1 ' .. exportedRuntimeMethods .. ' -lworkerfs.js'
+            '--define-macro=REAL_T_IS_DOUBLE -s ALLOW_MEMORY_GROWTH=1 -sGROWABLE_ARRAYBUFFERS=0 -s MAXIMUM_MEMORY=4GB -s FORCE_FILESYSTEM=1 -s EXPORT_NAME=conway_geom_native -s MODULARIZE=1 ' .. exportedRuntimeMethods .. ' -lworkerfs.js'
         }
 
     configuration {}
@@ -359,7 +359,7 @@ project "conway_geom_native_tests"
             "--bind",
             "-03",
             "-flto",
-            '--define-macro=REAL_T_IS_DOUBLE -s ALLOW_MEMORY_GROWTH=1 -s MAXIMUM_MEMORY=4GB -sSTACK_SIZE=5MB -s FORCE_FILESYSTEM=1 -s EXPORT_NAME=conway_geom_native_tests -s MODULARIZE=1 ' .. exportedRuntimeMethods .. ' -lworkerfs.js'
+            '--define-macro=REAL_T_IS_DOUBLE -s ALLOW_MEMORY_GROWTH=1 -sGROWABLE_ARRAYBUFFERS=0 -s MAXIMUM_MEMORY=4GB -sSTACK_SIZE=5MB -s FORCE_FILESYSTEM=1 -s EXPORT_NAME=conway_geom_native_tests -s MODULARIZE=1 ' .. exportedRuntimeMethods .. ' -lworkerfs.js'
         }
 
     configuration {}
@@ -523,7 +523,7 @@ project "webifc_native"
             "--bind",
             "-03",
             "-flto",
-            '--define-macro=REAL_T_IS_DOUBLE -s ALLOW_MEMORY_GROWTH=1 -s MAXIMUM_MEMORY=4GB -s FORCE_FILESYSTEM=1 -s EXPORT_NAME=webifc_native -s MODULARIZE=1 ' .. exportedRuntimeMethods .. ' -lworkerfs.js'
+            '--define-macro=REAL_T_IS_DOUBLE -s ALLOW_MEMORY_GROWTH=1 -sGROWABLE_ARRAYBUFFERS=0 -s MAXIMUM_MEMORY=4GB -s FORCE_FILESYSTEM=1 -s EXPORT_NAME=webifc_native -s MODULARIZE=1 ' .. exportedRuntimeMethods .. ' -lworkerfs.js'
         }
 
     configuration {}
@@ -661,6 +661,7 @@ project "webifc_native"
             "--define-macro=REAL_T_IS_DOUBLE",
             "-s ENVIRONMENT=node,worker",
             "-s ALLOW_MEMORY_GROWTH=1",
+            "-sGROWABLE_ARRAYBUFFERS=0",
             "-s MAXIMUM_MEMORY=4GB",
             "-s STACK_SIZE=10MB",
             "-s FORCE_FILESYSTEM=1",
@@ -691,6 +692,7 @@ project "webifc_native"
             "-flto",
             "--define-macro=REAL_T_IS_DOUBLE",
             "-s ALLOW_MEMORY_GROWTH=1",
+            "-sGROWABLE_ARRAYBUFFERS=0",
             "-s MAXIMUM_MEMORY=4GB",
             "-s STACK_SIZE=5MB",
             "-s FORCE_FILESYSTEM=1",
@@ -892,6 +894,7 @@ linkoptions {
     -- emscripten >= 6 needs the worker environment here, like the non-MT targets.
     "-s ENVIRONMENT=node,worker",
     "-s ALLOW_MEMORY_GROWTH=1",
+    "-sGROWABLE_ARRAYBUFFERS=0",
     "-s MAXIMUM_MEMORY=4GB",
     "-s STACK_SIZE=10MB",
     "-s FORCE_FILESYSTEM=1",
@@ -929,6 +932,7 @@ linkoptions {
     "-sPTHREAD_POOL_SIZE=\"" .. nodeCores .. "\"",
     "--define-macro=REAL_T_IS_DOUBLE",
     "-s ALLOW_MEMORY_GROWTH=1",
+    "-sGROWABLE_ARRAYBUFFERS=0",
     "-s MAXIMUM_MEMORY=4GB",
     "-s STACK_SIZE=5MB",
     "-s FORCE_FILESYSTEM=1",
@@ -1140,6 +1144,7 @@ if _ARGS[1] == "profile" and _ARGS[2] ~= nil then
         "-s PRECISE_F32=1",
         "-s ENVIRONMENT=web,worker",
         "-s ALLOW_MEMORY_GROWTH=1",
+        "-sGROWABLE_ARRAYBUFFERS=0",
         "-s MAXIMUM_MEMORY=4GB",
         "-s STACK_SIZE=5MB",
         "-s FORCE_FILESYSTEM=1",
@@ -1170,6 +1175,7 @@ else
         "--define-macro=REAL_T_IS_DOUBLE",
         "-s PRECISE_F32=1",
         "-s ALLOW_MEMORY_GROWTH=1",
+        "-sGROWABLE_ARRAYBUFFERS=0",
         "-s MAXIMUM_MEMORY=4GB",
         "-s STACK_SIZE=5MB",
         "-s FORCE_FILESYSTEM=1",
@@ -1365,6 +1371,7 @@ linkoptions {
     "--define-macro=REAL_T_IS_DOUBLE",
     "-sENVIRONMENT=web,worker",
     "-s ALLOW_MEMORY_GROWTH=1",
+    "-sGROWABLE_ARRAYBUFFERS=0",
     "-s MAXIMUM_MEMORY=4GB",
     "-s STACK_SIZE=5MB",
     "-s FORCE_FILESYSTEM=1",
@@ -1399,6 +1406,7 @@ linkoptions {
     "-sPTHREAD_POOL_SIZE=\"" .. webCores .. "\"",
     "--define-macro=REAL_T_IS_DOUBLE",
     "-s ALLOW_MEMORY_GROWTH=1",
+    "-sGROWABLE_ARRAYBUFFERS=0",
     "-s MAXIMUM_MEMORY=4GB",
     "-s STACK_SIZE=5MB",
     "-s FORCE_FILESYSTEM=1",


### PR DESCRIPTION
## Root cause

Emscripten **6.0.2** added `GROWABLE_ARRAYBUFFERS` and **defaulted it to `=1`** with `ALLOW_MEMORY_GROWTH`, exposing the browser wasm heap as an in-place **resizable `ArrayBuffer`** (`wasmMemory.toResizableBuffer()` in the glue). Strict browsers reject views over a resizable buffer in several Web APIs:

- `TextDecoder.decode()` throws (`"...can't be a resizable ArrayBuffer"`) → STEP faces silently dropped during extraction → **see-through geometry** in Chrome/Firefox (Safari tolerates it).
- The same incompatibility surfaces as `THREE.BufferGeometry … position has NaN` via WebGL / typed-array reads.

Emscripten **6.0.3 reverted this default to `=0`** — *"since we found issues with Web API compatibility"* — and separately fixed `UTF8ToString` to copy on resizable heaps. We're on 6.0.2, so we hit the regression.

## Fix

Set `-sGROWABLE_ARRAYBUFFERS=0` on all wasm targets (matching 6.0.3's default). The heap becomes a plain, non-resizable `ArrayBuffer` again, so `TextDecoder`, WebGL, and other Web APIs work normally.

## Verification

- **In headless Chromium**: the rebuilt Web module's `HEAPU8.buffer` is now `ArrayBuffer` with `resizable: false` (was a resizable buffer before).
- `Arty_Z7` regression digest **byte-identical** — this is a JS heap-wrapper change only, no geometry impact.

Complements the conway-side `TextDecoder` shim (bldrs-ai/conway#364), which still guards the threaded (growable-SharedArrayBuffer) build; this removes the resizable heap at the source for the single-threaded Web build and fixes the non-TextDecoder Web-API breakage too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz

---
_Generated by [Claude Code](https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz)_