### PR TITLE
Fix NURBS surface evaluation for real-valued knot ranges

### DIFF
--- a/conway_geometry/operations/mesh_utils.h
+++ b/conway_geometry/operations/mesh_utils.h
@@ -976,16 +976,26 @@ struct RationalNurbsInverseMethod {
 
     }
 
-    min_extent = glm::dvec2( 
-      srf.knots_u.size() < degreeU ? srf.knots_u[ degreeU ] : 0.0,
-      srf.knots_v.size() < degreeV ? srf.knots_v[ degreeV ] : 0.0 );
+    // The valid parameter domain of a clamped NURBS is
+    // [ knots[ degree ], knots[ knotCount - degree - 1 ] ] per axis. These
+    // comparisons were previously inverted (size < degree, which is never
+    // true for a valid knot vector), pinning the domain to [0,1]^2. IFC
+    // exporters normalise knots to 0..1 so it went unnoticed, but STEP
+    // (OCCT) writes real-valued knot ranges (e.g. u in [0, 200] down the
+    // length of a cylinder), and the [0,1] pin collapsed every rational
+    // b-spline face to a sliver - see conway#350 (AS1 rod invisible).
+    min_extent = glm::dvec2(
+      srf.knots_u.size() > degreeU ? srf.knots_u[ degreeU ] : 0.0,
+      srf.knots_v.size() > degreeV ? srf.knots_v[ degreeV ] : 0.0 );
 
+    // Unsigned underflow when knots.size() < degree + 1 makes uM/vM huge,
+    // so the bounds check below also rejects that malformed case.
     size_t uM = srf.knots_u.size() - ( degreeU + 1 );
     size_t vM = srf.knots_v.size() - ( degreeV + 1 );
 
-    max_extent = glm::dvec2( 
-      srf.knots_u.size() < uM ? srf.knots_u[ srf.knots_u.size() - ( degreeU + 1 ) ] : 1.0,
-      srf.knots_v.size() < vM ? srf.knots_v[ srf.knots_v.size() - ( degreeV + 1 ) ] : 1.0 );
+    max_extent = glm::dvec2(
+      uM < srf.knots_u.size() ? srf.knots_u[ uM ] : 1.0,
+      vM < srf.knots_v.size() ? srf.knots_v[ vM ] : 1.0 );
 
 
     for ( size_t i = 0; i < INVERSE_GRID_SIDE; ++i ) {
@@ -1219,8 +1229,13 @@ inline void TriangulateBspline(Geometry &geometry,
 
   std::vector<double> weights;
   weights.reserve( num_u * num_v );
-  // for (std::vector<double> row : surface.BSplineSurface.WeightPoints) {
-  for (const std::vector<double>& row : surface.BSplineSurface.Weights) {
+  // Read WeightPoints, not Weights: WeightPoints is the field the embind
+  // surface parameters (and the IFC GetSurface path) actually populate.
+  // Weights has no writer anywhere, so reading it always fell through to
+  // the all-1.0 default below and rational surfaces (e.g. STEP cylinders
+  // written as weighted Bezier arcs) evaluated as plain polynomials,
+  // bulging the profile - part of conway#350.
+  for (const std::vector<double>& row : surface.BSplineSurface.WeightPoints) {
     for (double weight : row) {
       weights.push_back(weight);
     }

--- a/conway_geometry/operations/nurbs_utils.h
+++ b/conway_geometry/operations/nurbs_utils.h
@@ -80,6 +80,13 @@ struct RationalSurfaceEvaluator {
     // Index of the last knot span start (n = knotCount - degree - 2).
     int n = static_cast< int >( knots.size() ) - static_cast< int >( degree ) - 2;
 
+    // Degenerate knot vector (fewer than degree + 2 knots) - callers
+    // validate with surfaceIsValid first so this shouldn't happen, but an
+    // out-of-bounds read in wasm is silent garbage, so fail safe.
+    if ( n < 0 ) {
+      return static_cast< int >( degree );
+    }
+
     if ( u >= knots[ n + 1 ] ) {
       return n;
     }
@@ -114,6 +121,10 @@ struct RationalSurfaceEvaluator {
    */
   static double clampBelowLastKnot(
       uint32_t degree, const std::vector< double >& knots, double u ) {
+
+    if ( knots.size() < degree + 1 ) {
+      return u;
+    }
 
     double lastKnot = knots[ knots.size() - degree - 1 ];
 

--- a/conway_geometry/operations/nurbs_utils.h
+++ b/conway_geometry/operations/nurbs_utils.h
@@ -2,7 +2,9 @@
 
 #include <tinynurbs/tinynurbs.h>
 
+#include <cmath>
 #include <glm/glm.hpp>
+#include <limits>
 #include <tuple>
 #include <vector>
 
@@ -60,18 +62,80 @@ struct RationalSurfaceEvaluator {
     }
   }
 
+  /**
+   * Knot-span lookup (The NURBS Book A2.1). tinynurbs::findSpan guards the
+   * domain ends with an ABSOLUTE epsilon (numeric_limits::epsilon), which is
+   * below one ULP for knot values > 2 - e.g. STEP surfaces whose parameter
+   * range is a real length like [0, 200]. There `lastKnot - epsilon` rounds
+   * back to lastKnot, the guard never fires for u == lastKnot, and its
+   * binary search (`low = mid` with mid pinned by integer division) spins
+   * forever. Exact >= / <= boundary guards make the search invariant
+   * (knots[low] <= u < knots[high]) hold strictly, so it always terminates.
+   */
+  static int findSpan(
+      uint32_t degree,
+      const std::vector< double >& knots,
+      double u ) {
+
+    // Index of the last knot span start (n = knotCount - degree - 2).
+    int n = static_cast< int >( knots.size() ) - static_cast< int >( degree ) - 2;
+
+    if ( u >= knots[ n + 1 ] ) {
+      return n;
+    }
+
+    if ( u <= knots[ degree ] ) {
+      return degree;
+    }
+
+    int low  = degree;
+    int high = n + 1;
+    int mid  = ( low + high ) / 2;
+
+    while ( u < knots[ mid ] || u >= knots[ mid + 1 ] ) {
+
+      if ( u < knots[ mid ] ) {
+        high = mid;
+      } else {
+        low = mid;
+      }
+
+      mid = ( low + high ) / 2;
+    }
+
+    return mid;
+  }
+
+  /**
+   * Clamp a parameter strictly below the last knot so the tinynurbs
+   * fallback (degree > NURBS_MAX_STACK_DEGREE) can never enter
+   * tinynurbs::findSpan's non-terminating end-of-domain case (see
+   * findSpan above).
+   */
+  static double clampBelowLastKnot(
+      uint32_t degree, const std::vector< double >& knots, double u ) {
+
+    double lastKnot = knots[ knots.size() - degree - 1 ];
+
+    return u >= lastKnot ?
+      std::nextafter( lastKnot, -std::numeric_limits< double >::infinity() ) : u;
+  }
+
   /** Point on the surface, matching tinynurbs::surfacePoint( rational ). */
   glm::dvec3 point( double u, double v ) const {
 
     if ( !fastPath_ ) {
-      return tinynurbs::surfacePoint( surface_, u, v );
+      return tinynurbs::surfacePoint(
+        surface_,
+        clampBelowLastKnot( surface_.degree_u, surface_.knots_u, u ),
+        clampBelowLastKnot( surface_.degree_v, surface_.knots_v, v ) );
     }
 
     uint32_t degreeU = surface_.degree_u;
     uint32_t degreeV = surface_.degree_v;
 
-    int spanU = tinynurbs::findSpan( degreeU, surface_.knots_u, u );
-    int spanV = tinynurbs::findSpan( degreeV, surface_.knots_v, v );
+    int spanU = findSpan( degreeU, surface_.knots_u, u );
+    int spanV = findSpan( degreeV, surface_.knots_v, v );
 
     double basisU[ NURBS_MAX_STACK_DEGREE + 1 ];
     double basisV[ NURBS_MAX_STACK_DEGREE + 1 ];
@@ -105,14 +169,17 @@ struct RationalSurfaceEvaluator {
   std::tuple< glm::dvec3, glm::dvec3 > tangent( double u, double v ) const {
 
     if ( !fastPath_ ) {
-      return tinynurbs::surfaceTangent( surface_, u, v );
+      return tinynurbs::surfaceTangent(
+        surface_,
+        clampBelowLastKnot( surface_.degree_u, surface_.knots_u, u ),
+        clampBelowLastKnot( surface_.degree_v, surface_.knots_v, v ) );
     }
 
     uint32_t degreeU = surface_.degree_u;
     uint32_t degreeV = surface_.degree_v;
 
-    int spanU = tinynurbs::findSpan( degreeU, surface_.knots_u, u );
-    int spanV = tinynurbs::findSpan( degreeV, surface_.knots_v, v );
+    int spanU = findSpan( degreeU, surface_.knots_u, u );
+    int spanV = findSpan( degreeV, surface_.knots_v, v );
 
     // ders[ 0 ] = basis values, ders[ 1 ] = first derivatives.
     double dersU[ 2 ][ NURBS_MAX_STACK_DEGREE + 1 ];


### PR DESCRIPTION
## Summary
This PR fixes critical bugs in NURBS surface evaluation that caused rational B-spline surfaces with real-valued knot ranges (e.g., STEP format cylinders) to be incorrectly evaluated or rendered as slivers. The issues affected both the fast path (custom implementation) and fallback path (tinynurbs library).

## Key Changes

### nurbs_utils.h
- **Added custom `findSpan()` implementation**: Replaces tinynurbs::findSpan which has a non-terminating infinite loop bug when evaluating at the last knot with large knot values. The custom implementation uses exact boundary guards (`>=` / `<=`) instead of epsilon comparisons, making the binary search invariant strictly hold and ensuring termination.
- **Added `clampBelowLastKnot()` helper**: Clamps parameters strictly below the last knot using `std::nextafter()` to prevent the tinynurbs fallback from entering its broken end-of-domain case.
- **Updated `point()` and `tangent()` methods**: 
  - Fast path now uses the custom `findSpan()` instead of tinynurbs::findSpan
  - Fallback path now clamps parameters before calling tinynurbs functions
- **Added necessary headers**: `<cmath>` and `<limits>` for `std::nextafter()` and `std::numeric_limits`

### mesh_utils.h
- **Fixed parameter domain bounds calculation**: Corrected inverted comparison operators (`<` → `>`) when extracting min/max knot extents. Previous logic `size < degree` was never true for valid knot vectors, incorrectly pinning all domains to [0,1]² regardless of actual knot ranges.
- **Simplified max extent calculation**: Changed from redundant size checks to direct index bounds checking using pre-computed `uM`/`vM` values.
- **Fixed weight reading**: Changed from reading `Weights` (never populated) to `WeightPoints` (the actual field populated by embind and IFC GetSurface). This ensures rational surfaces evaluate correctly instead of falling back to polynomial evaluation.
- **Added clarifying comments**: Documented the parameter domain formula and the unsigned underflow edge case.

## Impact
These fixes enable proper evaluation of NURBS surfaces with arbitrary knot ranges, particularly important for STEP format files where knot values represent real geometric dimensions (e.g., [0, 200] along a cylinder's length). Resolves issue conway#350 where rational B-spline faces were rendered as invisible slivers.

https://claude.ai/code/session_01J3A79iKimn7UheESvnumj7