### PR TITLE
Fix toroidal dual-parameterization fold that dropped tube fillet faces (#47)

### DIFF
--- a/conway_geometry/operations/mesh_utils.h
+++ b/conway_geometry/operations/mesh_utils.h
@@ -339,25 +339,27 @@ inline void TriangulateToroidalSurface(
       // Project the point onto the unit sphere surface
       return ( normalRingCentre * 3.0 ) + normalPointOnRing;
     },
+    // Unwrap the tube cross-section (minor angle phi) to a 2D annulus, radius
+    // 1.5 +/- 0.5 (inner hole 1.0, outer ring 2.0). normalForm packs
+    //   xy = (3 + cos phi) * ringDir(theta),  z = sin phi,
+    // so the tube radius is recoverable from the planar MAGNITUDE:
+    //   radius = 0.5 * |xy| = 1.5 + 0.5*cos phi,   direction = normalize(xy).
+    // Together that is just `xy * 0.5`. The previous form used
+    // `normalize(xy) * (1 + (1 +/- z)*0.5)`, i.e. it drove the radius from z =
+    // sin phi, which is 2-to-1 over each tube half: the inner equator (phi=pi,
+    // xy=(2,0)) and outer equator (phi=0, xy=(4,0)) both collapsed onto radius
+    // 1.5. Those coincident-in-2D-but-distinct-in-3D boundary points made CDT
+    // reject the face (intersecting constraints / duplicate vertex), dropping
+    // toroidal fillet faces - e.g. the jet-engine turbine shaft, test-models
+    // issue #47. cos phi (via |xy|) is monotonic across each hemisphere, so the
+    // unwrap is now injective and the equators land at distinct radii (1 and 2).
     [&]( const glm::dvec3& normalFormVertex ) {
 
-      const double z = ( 1 + normalFormVertex.z );
-
-      glm::dvec2 originalPlanar   = glm::dvec2( normalFormVertex );
-      glm::dvec2 normalRingCentre = glm::normalize( originalPlanar );
-
-      // Range [-2, 2], ring is radiug 1.5 +/- 0.5 (inner hole is 1.0, outer ring is 2)
-      return normalRingCentre * ( 1.0 + z * 0.5 );
+      return glm::dvec2( normalFormVertex ) * 0.5;
     },
     [&]( const glm::dvec3& normalFormVertex ) {
 
-      const double z = ( 1 - normalFormVertex.z );
-
-      glm::dvec2 originalPlanar   = glm::dvec2( normalFormVertex );
-      glm::dvec2 normalRingCentre = glm::normalize( originalPlanar );
-
-      // Range [-2, 2], ring is radiug 1.5 +/- 0.5 (inner hole is 1.0, outer ring is 2)
-      return normalRingCentre * ( 1.0 + z * 0.5 );
+      return glm::dvec2( normalFormVertex ) * 0.5;
     },
     []( const glm::dvec3& normalFormVertex ) {
 


### PR DESCRIPTION
## Summary

Fixes the residual dropped-faces issue on the jet-engine turbine shaft in bldrs-ai/test-models#47. The turbine shaft's toroidal tube fillets were silently dropped (error-tolerated) with 18 CDT exceptions; this recovers them with a one-hunk change to `TriangulateToroidalSurface`.

## Root cause

`TriangulateToroidalSurface` unwraps the tube cross-section (minor angle φ) to a 2D annulus for CDT. The normal form packs:

```
xy = (3 + cos φ) · ringDir(θ),   z = sin φ
```

but the parameterization drove the annulus **radius from `z = sin φ`** (`normalize(xy) * (1 + (1 ± z)·0.5)`). `sin φ` is **2-to-1 over each tube half**, so the inner equator (φ=π, xy=(2,0)) and the outer equator (φ=0, xy=(4,0)) both collapse onto radius 1.5 — the same 2D point.

I instrumented the CDT input to confirm: every bit-exact 2D-coincident vertex pair comes from 3D points **2 units apart** on the tube, e.g.

```
coincident 2D (1.5,0):  cdt#23  (3D 2,0,0)  == cdt#133 (3D 4,0,0)   dist3d = 2
coincident 2D (-1.5,0): cdt#138 (3D -4,0,0) == cdt#161 (3D -2,0,0)  dist3d = 2
```

Two genuinely-distinct boundary vertices become one point in the projection, so CDT (`IntersectingConstraintEdges::NotAllowed`) rejects the face with *intersecting constraint edges* / *duplicate vertex*. This is why a 2D weld/dedup can't fix it — the coincident points are 2mm apart in 3D and welding would corrupt the tube.

## Fix

The tube radius is recoverable from the planar **magnitude**: `radius = 0.5·|xy| = 1.5 + 0.5·cos φ`, direction `normalize(xy)` — i.e. simply `xy · 0.5`. `cos φ` is monotonic across each hemisphere, so the unwrap becomes injective and the two equators land at distinct radii (1 and 2). This also removes intra-hemisphere folds (the old form folded whenever a face crossed φ=π/2, not only at the equator).

## Verification

- `Jetenginestep.stp`: **18 CDT exceptions → 0**, and ~55k more triangles committed (the recovered shaft fillet faces). CDT succeeding under `NotAllowed` is itself proof the projected boundary is now non-self-crossing (a valid constrained-Delaunay triangulation of injective input).
- `nist_ctc_04_asme1_rd.stp` (sphere-based errors): **unchanged 29 → 29**, confirming this torus-only change is well-scoped and does not disturb the separate spherical pole degeneracy.

## Scope notes

- **Digest-moving.** Every toroidal face now tessellates through the corrected unwrap, so regression geometry baselines covering toroidal surfaces will shift and need re-blessing. Please review the shape-diff renderings for the toroidal-surface models.
- The **spherical** dual-parameterization has its own, separate pole degeneracy (e.g. the nist_ctc_04 hemisphere errors) that this change intentionally does not touch — worth a follow-up issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J3A79iKimn7UheESvnumj7

---
_Generated by [Claude Code](https://claude.ai/code/session_01J3A79iKimn7UheESvnumj7)_