### PR TITLE
TilePool + wasm bindings: resident tile pool (fixed chunks + refcounted assets) through the JS boundary

### DIFF
--- a/conway-api.cpp
+++ b/conway-api.cpp
@@ -12,6 +12,7 @@
 #include "structures/parse_buffer.h"
 #include "conway_geometry/ConwayGeometryProcessor.h"
 #include "conway_geometry/structures/alloc_telemetry.h"
+#include "conway_geometry/structures/tile_pool_api.h"
 #include "logging/Logger.h"
 
 
@@ -912,6 +913,153 @@ glm::dmat4 invert4x4( const glm::dmat4& mat ) {
 glm::dmat3 transpose3x3(const glm::dmat3& mat) {
     return glm::transpose(mat);
 }
+
+namespace {
+
+// --- Geometry tile pool glue (demand-driven residency; see
+// conway_geometry/structures/tile_pool_api.h for the payload layout and
+// bldrs-ai/conway design/new/streaming-federated-loader.md "Resident
+// memory: two regimes" for the design). Asset ids and sizes cross the JS
+// boundary as doubles (safe: express/local ids and byte sizes are well
+// under 2^53).
+
+bool InitGeometryTilePool(double budgetBytes, double chunkBytes) {
+  if (budgetBytes < 0 || chunkBytes < 0) {
+    return false;
+  }
+
+  return conway::tilePoolInit(static_cast<std::size_t>(budgetBytes),
+                              static_cast<std::size_t>(chunkBytes));
+}
+
+bool GeometryTilePoolInitialized() { return conway::tilePoolInitialized(); }
+
+/// Commit a reified geometry's GPU payload (header + float vertex data +
+/// uint32 index data) into pool chunks — the tessellation-commit seam. The
+/// fat working Geometry (dvec3 vertices, triangles, edge maps) can be
+/// dropped afterwards; the tile alone serves (re-)upload.
+bool CommitGeometryTile(double assetId,
+                        conway::geometry::Geometry& geometry) {
+  const std::uint32_t vertexFloats = geometry.GetVertexDataSize();
+  const std::uint32_t indexCount = geometry.GetIndexDataSize();
+
+  const std::uint32_t header[2] = {
+      static_cast<std::uint32_t>(vertexFloats * sizeof(float)),
+      static_cast<std::uint32_t>(indexCount * sizeof(std::uint32_t))};
+
+  // GetVertexData/GetIndexData return module-memory addresses (wasm32).
+  const auto* vertexBytes = reinterpret_cast<const std::byte*>(
+      static_cast<std::uintptr_t>(geometry.GetVertexData()));
+  const auto* indexBytes = reinterpret_cast<const std::byte*>(
+      static_cast<std::uintptr_t>(geometry.GetIndexData()));
+
+  const conway::TilePool::PayloadPart parts[3] = {
+      {reinterpret_cast<const std::byte*>(header), sizeof(header)},
+      {vertexBytes, header[0]},
+      {indexBytes, header[1]},
+  };
+
+  conway::TilePool* pool = conway::moduleTilePool().get();
+
+  if (pool == nullptr || pool->isResident(static_cast<conway::AssetId>(assetId))) {
+    return false;
+  }
+
+  return pool->commitAssetParts(static_cast<conway::AssetId>(assetId), parts, 3);
+}
+
+/// Commit a raw payload already in module memory (generic tiles; also the
+/// binding-level test path).
+bool CommitGeometryTileBytes(double assetId, double sourceAddress,
+                             double byteLength) {
+  return conway::tilePoolCommitBytes(
+      static_cast<conway::AssetId>(assetId),
+      reinterpret_cast<const std::byte*>(
+          static_cast<std::uintptr_t>(sourceAddress)),
+      static_cast<std::size_t>(byteLength));
+}
+
+bool RetainGeometryTile(double assetId) {
+  return conway::tilePoolRetain(static_cast<conway::AssetId>(assetId));
+}
+
+bool ReleaseGeometryTile(double assetId) {
+  return conway::tilePoolRelease(static_cast<conway::AssetId>(assetId));
+}
+
+bool GeometryTileResident(double assetId) {
+  return conway::tilePoolIsResident(static_cast<conway::AssetId>(assetId));
+}
+
+double GeometryTileRefCount(double assetId) {
+  return conway::tilePoolRefCount(static_cast<conway::AssetId>(assetId));
+}
+
+double GeometryTileByteSize(double assetId) {
+  return static_cast<double>(
+      conway::tilePoolByteSize(static_cast<conway::AssetId>(assetId)));
+}
+
+double GeometryTileSegmentCount(double assetId) {
+  return static_cast<double>(
+      conway::tilePoolSegmentCount(static_cast<conway::AssetId>(assetId)));
+}
+
+double GeometryTileSegmentAddress(double assetId, double segment) {
+  return static_cast<double>(conway::tilePoolSegmentAddress(
+      static_cast<conway::AssetId>(assetId),
+      static_cast<std::size_t>(segment)));
+}
+
+double GeometryTileSegmentByteLength(double assetId, double segment) {
+  return static_cast<double>(conway::tilePoolSegmentByteLength(
+      static_cast<conway::AssetId>(assetId),
+      static_cast<std::size_t>(segment)));
+}
+
+/// Header readers for geometry tiles (byte lengths of the two payload
+/// spans). The 8-byte header is contiguous in the first segment by the
+/// init-time chunk-size floor.
+double GeometryTileVertexByteLength(double assetId) {
+  const std::uintptr_t address = conway::tilePoolSegmentAddress(
+      static_cast<conway::AssetId>(assetId), 0);
+
+  if (address == 0) {
+    return 0;
+  }
+
+  return *reinterpret_cast<const std::uint32_t*>(address);
+}
+
+double GeometryTileIndexByteLength(double assetId) {
+  const std::uintptr_t address = conway::tilePoolSegmentAddress(
+      static_cast<conway::AssetId>(assetId), 0);
+
+  if (address == 0) {
+    return 0;
+  }
+
+  return *(reinterpret_cast<const std::uint32_t*>(address) + 1);
+}
+
+double GeometryTilePoolBytesInUse() {
+  return static_cast<double>(conway::tilePoolStats().bytesInUse);
+}
+
+double GeometryTilePoolTotalBytes() {
+  conway::TilePool* pool = conway::moduleTilePool().get();
+  return pool == nullptr ? 0 : static_cast<double>(pool->totalBytes());
+}
+
+double GeometryTilePoolFreeChunks() {
+  return static_cast<double>(conway::tilePoolStats().freeChunks);
+}
+
+double GeometryTilePoolFailedCommits() {
+  return static_cast<double>(conway::tilePoolStats().failedCommits);
+}
+
+}  // namespace
 
 EMSCRIPTEN_BINDINGS(my_module) {
   /*
@@ -1892,8 +2040,37 @@ EMSCRIPTEN_BINDINGS(my_module) {
   emscripten::function("getPolyCurve", &GetPolyCurve,
                        emscripten::allow_raw_pointers());
 
-  emscripten::function("resizeVectorVectorDouble", 
+  emscripten::function("resizeVectorVectorDouble",
   &resizeVectorVectorDouble, emscripten::allow_raw_pointers());
-  emscripten::function("getSweptDiskSolid", 
+  emscripten::function("getSweptDiskSolid",
   &GetSweptDiskSolid, emscripten::allow_raw_pointers());
+
+  // Geometry tile pool (demand-driven residency — see tile_pool_api.h).
+  emscripten::function("initGeometryTilePool", &InitGeometryTilePool);
+  emscripten::function("geometryTilePoolInitialized",
+                       &GeometryTilePoolInitialized);
+  emscripten::function("commitGeometryTile", &CommitGeometryTile);
+  emscripten::function("commitGeometryTileBytes", &CommitGeometryTileBytes);
+  emscripten::function("retainGeometryTile", &RetainGeometryTile);
+  emscripten::function("releaseGeometryTile", &ReleaseGeometryTile);
+  emscripten::function("geometryTileResident", &GeometryTileResident);
+  emscripten::function("geometryTileRefCount", &GeometryTileRefCount);
+  emscripten::function("geometryTileByteSize", &GeometryTileByteSize);
+  emscripten::function("geometryTileSegmentCount", &GeometryTileSegmentCount);
+  emscripten::function("geometryTileSegmentAddress",
+                       &GeometryTileSegmentAddress);
+  emscripten::function("geometryTileSegmentByteLength",
+                       &GeometryTileSegmentByteLength);
+  emscripten::function("geometryTileVertexByteLength",
+                       &GeometryTileVertexByteLength);
+  emscripten::function("geometryTileIndexByteLength",
+                       &GeometryTileIndexByteLength);
+  emscripten::function("geometryTilePoolBytesInUse",
+                       &GeometryTilePoolBytesInUse);
+  emscripten::function("geometryTilePoolTotalBytes",
+                       &GeometryTilePoolTotalBytes);
+  emscripten::function("geometryTilePoolFreeChunks",
+                       &GeometryTilePoolFreeChunks);
+  emscripten::function("geometryTilePoolFailedCommits",
+                       &GeometryTilePoolFailedCommits);
 }

--- a/conway_geometry/structures/tile_pool.h
+++ b/conway_geometry/structures/tile_pool.h
@@ -151,9 +151,17 @@ class TilePool {
   /// discontiguous parts — the real tessellation-commit shape (a small
   /// header plus the reified vertex and index vectors), copied straight
   /// into chunks with no intermediate contiguous buffer.
+  ///
+  /// Committing an already-resident asset is a caller bug (use retainAsset);
+  /// it asserts in debug and returns false with no state change in release —
+  /// never a silent chunk leak.
   bool commitAssetParts(AssetId asset, const PayloadPart* parts,
                         std::size_t partCount) {
     assert(assets_.find(asset) == assets_.end());
+
+    if (assets_.find(asset) != assets_.end()) {
+      return false;
+    }
 
     std::size_t byteSize = 0;
 
@@ -213,9 +221,18 @@ class TilePool {
   /// Drop a reference. On the last reference the asset's chunks return to
   /// the freelist and true is returned (the caller's cue to drop any
   /// derived state, e.g. GPU buffers).
+  ///
+  /// Releasing a non-resident asset is a caller bug; it asserts in debug and
+  /// returns false with no state change in release — never UB on a missing
+  /// entry.
   bool releaseAsset(AssetId asset) {
     auto found = assets_.find(asset);
     assert(found != assets_.end());
+
+    if (found == assets_.end()) {
+      return false;
+    }
+
     ++releases_;
 
     if (--found->second.refCount > 0) {
@@ -238,12 +255,18 @@ class TilePool {
 
   /// Pointer + byte length of one of an asset's segments, in payload order.
   /// Valid until the asset's last release. This is the zero-copy consumption
-  /// path (e.g. one bufferSubData per segment at GPU upload).
+  /// path (e.g. one bufferSubData per segment at GPU upload). A missing asset
+  /// or out-of-range index asserts in debug and returns {nullptr, 0} in
+  /// release.
   std::pair<const std::byte*, std::size_t> segmentOf(AssetId asset,
                                                      std::size_t index) const {
     auto found = assets_.find(asset);
     assert(found != assets_.end());
-    assert(index < found->second.chunks.size());
+    assert(found == assets_.end() || index < found->second.chunks.size());
+
+    if (found == assets_.end() || index >= found->second.chunks.size()) {
+      return {nullptr, 0};
+    }
 
     const Asset& entry = found->second;
     const std::size_t offset = index * chunkBytes_;
@@ -255,10 +278,15 @@ class TilePool {
   }
 
   /// Gather-copy an asset's payload into contiguous storage (the copying
-  /// consumption path). `destination` must hold byteSizeOf(asset).
-  void readAsset(AssetId asset, std::byte* destination) const {
+  /// consumption path). `destination` must hold byteSizeOf(asset). A missing
+  /// asset asserts in debug and returns false (no copy) in release.
+  bool readAsset(AssetId asset, std::byte* destination) const {
     auto found = assets_.find(asset);
     assert(found != assets_.end());
+
+    if (found == assets_.end()) {
+      return false;
+    }
 
     const Asset& entry = found->second;
     std::size_t copied = 0;
@@ -271,6 +299,8 @@ class TilePool {
       std::memcpy(destination + copied, chunkData(chunk), span);
       copied += span;
     }
+
+    return true;
   }
 
   Stats stats() const {

--- a/conway_geometry/structures/tile_pool.h
+++ b/conway_geometry/structures/tile_pool.h
@@ -1,0 +1,275 @@
+#pragma once
+
+/*
+ * Resident tile pool — the C++ twin of conway's TS memory system
+ * (bldrs-ai/conway src/core/mem/: ChunkedPool + SharedAssetPool), for the
+ * demand-driven geometry residency design ("Resident memory: two regimes" in
+ * design/new/streaming-federated-loader.md).
+ *
+ * Why not per-asset malloc/free: wasm linear memory never shrinks, so the tab
+ * pays the heap's high-water mark forever and evict/refill churn turns
+ * fragmentation into a permanent leak. This pool allocates ONE region at init
+ * (the byte budget, paid deliberately and exactly once), carves it into
+ * fixed-size chunks with a freelist, and serves refcounted assets out of
+ * those chunks. The region's high-water mark is the budget by construction;
+ * fragmentation reduces to bounded internal waste in each asset's last chunk.
+ *
+ * Lifetime regimes, for orientation: tessellation *scratch* (phase-bounded,
+ * dies at commit) stays on the per-thread ScratchArena — this pool is for
+ * *demand-bounded residents*: committed tile payloads that live until the
+ * scheduler evicts them. The commit copy is AFTP phase 2's exact-size commit,
+ * redirected from the general heap into pool chunks.
+ *
+ * Sharing: assets are refcounted (the instance ⇄ asset / occurrence ⇄
+ * definition relationship — many products, one mapped representation).
+ * Storage is keyed on the asset, so releasing one holder never frees a
+ * payload another still references; chunks return to the freelist on the
+ * last release only. The scheduling/budget policy lives TS-side
+ * (DemandGeometryQueue + GeometryTilePool); this type owns bytes and
+ * refcounts only, and its accounting mirrors the TS spec so the two sides
+ * agree chunk-for-chunk.
+ *
+ * A tile's chunks are generally NON-CONTIGUOUS. Consumers either walk the
+ * per-chunk segments (e.g. one gl.bufferSubData per chunk at GPU upload) or
+ * gather-copy out via readAsset(). Payload writers scatter-copy in via
+ * commitAsset().
+ *
+ * Not thread-safe: confine a pool to one thread (the geometry worker that
+ * owns residency) or guard it externally.
+ */
+
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <unordered_map>
+#include <vector>
+
+namespace conway {
+
+/// Stable identity of a shareable resident payload. For IFC geometry this is
+/// the representation's local ID (mapped items make many products carry the
+/// same AssetId); nothing in the pool is geometry-specific.
+using AssetId = std::uint64_t;
+
+class TilePool {
+ public:
+  struct Stats {
+    std::size_t totalChunks = 0;
+    std::size_t freeChunks = 0;
+    std::size_t bytesInUse = 0;   // physical, chunk-rounded
+    std::size_t assetCount = 0;
+    std::size_t commits = 0;
+    std::size_t retains = 0;
+    std::size_t releases = 0;
+    std::size_t failedCommits = 0;
+  };
+
+  /// One region, allocated exactly once. budgetBytes rounds down to whole
+  /// chunks and must fit at least one chunk.
+  TilePool(std::size_t budgetBytes, std::size_t chunkBytes)
+      : chunkBytes_(chunkBytes), totalChunks_(budgetBytes / chunkBytes) {
+    assert(chunkBytes_ > 0);
+    assert(totalChunks_ >= 1);
+
+    region_.resize(totalChunks_ * chunkBytes_);
+    freeList_.reserve(totalChunks_);
+
+    for (std::size_t chunk = totalChunks_; chunk-- > 0;) {
+      freeList_.push_back(static_cast<std::uint32_t>(chunk));
+    }
+  }
+
+  TilePool(const TilePool&) = delete;
+  TilePool& operator=(const TilePool&) = delete;
+
+  std::size_t chunkBytes() const { return chunkBytes_; }
+  std::size_t totalChunks() const { return totalChunks_; }
+  std::size_t freeChunks() const { return freeList_.size(); }
+  std::size_t totalBytes() const { return totalChunks_ * chunkBytes_; }
+
+  std::size_t bytesInUse() const {
+    return (totalChunks_ - freeList_.size()) * chunkBytes_;
+  }
+
+  /// The physical (chunk-rounded) cost of a byte size — what a commit of
+  /// `bytes` actually consumes. Budget layers above use this so logical
+  /// charges cover physical use (the TS-side invariant).
+  std::size_t chunkRound(std::size_t bytes) const {
+    return ((bytes + chunkBytes_ - 1) / chunkBytes_) * chunkBytes_;
+  }
+
+  bool isResident(AssetId asset) const {
+    return assets_.find(asset) != assets_.end();
+  }
+
+  std::uint32_t refCountOf(AssetId asset) const {
+    auto found = assets_.find(asset);
+    return found == assets_.end() ? 0u : found->second.refCount;
+  }
+
+  std::size_t byteSizeOf(AssetId asset) const {
+    auto found = assets_.find(asset);
+    return found == assets_.end() ? 0u : found->second.byteSize;
+  }
+
+  /// Take a reference on an already-resident asset. Returns false if the
+  /// asset is absent — the caller's cue to extract into scratch and
+  /// commitAsset(). (Split from commit because only the caller can produce
+  /// the payload; TS's unified retain() maps onto retain-else-commit here.)
+  bool retainAsset(AssetId asset) {
+    auto found = assets_.find(asset);
+
+    if (found == assets_.end()) {
+      return false;
+    }
+
+    ++found->second.refCount;
+    ++retains_;
+    return true;
+  }
+
+  /// Make an asset resident with refCount 1 by scatter-copying `byteSize`
+  /// bytes from `payload` into freshly acquired chunks. All-or-nothing:
+  /// returns false (and changes nothing) if the free chunks can't cover it —
+  /// the scheduler's cue to evict and retry. The asset must not already be
+  /// resident (use retainAsset first).
+  bool commitAsset(AssetId asset, const std::byte* payload,
+                   std::size_t byteSize) {
+    assert(assets_.find(asset) == assets_.end());
+
+    const std::size_t needed = (byteSize + chunkBytes_ - 1) / chunkBytes_;
+
+    if (needed > freeList_.size()) {
+      ++failedCommits_;
+      return false;
+    }
+
+    Asset entry;
+    entry.byteSize = byteSize;
+    entry.refCount = 1;
+    entry.chunks.reserve(needed);
+
+    std::size_t copied = 0;
+
+    for (std::size_t where = 0; where < needed; ++where) {
+      const std::uint32_t chunk = freeList_.back();
+      freeList_.pop_back();
+      entry.chunks.push_back(chunk);
+
+      const std::size_t span =
+          byteSize - copied < chunkBytes_ ? byteSize - copied : chunkBytes_;
+
+      std::memcpy(chunkData(chunk), payload + copied, span);
+      copied += span;
+    }
+
+    assets_.emplace(asset, std::move(entry));
+    ++commits_;
+    return true;
+  }
+
+  /// Drop a reference. On the last reference the asset's chunks return to
+  /// the freelist and true is returned (the caller's cue to drop any
+  /// derived state, e.g. GPU buffers).
+  bool releaseAsset(AssetId asset) {
+    auto found = assets_.find(asset);
+    assert(found != assets_.end());
+    ++releases_;
+
+    if (--found->second.refCount > 0) {
+      return false;
+    }
+
+    for (const std::uint32_t chunk : found->second.chunks) {
+      freeList_.push_back(chunk);
+    }
+
+    assets_.erase(found);
+    return true;
+  }
+
+  /// Number of chunk segments an asset occupies (for per-segment consumers).
+  std::size_t segmentCountOf(AssetId asset) const {
+    auto found = assets_.find(asset);
+    return found == assets_.end() ? 0u : found->second.chunks.size();
+  }
+
+  /// Pointer + byte length of one of an asset's segments, in payload order.
+  /// Valid until the asset's last release. This is the zero-copy consumption
+  /// path (e.g. one bufferSubData per segment at GPU upload).
+  std::pair<const std::byte*, std::size_t> segmentOf(AssetId asset,
+                                                     std::size_t index) const {
+    auto found = assets_.find(asset);
+    assert(found != assets_.end());
+    assert(index < found->second.chunks.size());
+
+    const Asset& entry = found->second;
+    const std::size_t offset = index * chunkBytes_;
+    const std::size_t span = entry.byteSize - offset < chunkBytes_
+                                 ? entry.byteSize - offset
+                                 : chunkBytes_;
+
+    return {chunkData(entry.chunks[index]), span};
+  }
+
+  /// Gather-copy an asset's payload into contiguous storage (the copying
+  /// consumption path). `destination` must hold byteSizeOf(asset).
+  void readAsset(AssetId asset, std::byte* destination) const {
+    auto found = assets_.find(asset);
+    assert(found != assets_.end());
+
+    const Asset& entry = found->second;
+    std::size_t copied = 0;
+
+    for (const std::uint32_t chunk : entry.chunks) {
+      const std::size_t span = entry.byteSize - copied < chunkBytes_
+                                   ? entry.byteSize - copied
+                                   : chunkBytes_;
+
+      std::memcpy(destination + copied, chunkData(chunk), span);
+      copied += span;
+    }
+  }
+
+  Stats stats() const {
+    Stats result;
+    result.totalChunks = totalChunks_;
+    result.freeChunks = freeList_.size();
+    result.bytesInUse = bytesInUse();
+    result.assetCount = assets_.size();
+    result.commits = commits_;
+    result.retains = retains_;
+    result.releases = releases_;
+    result.failedCommits = failedCommits_;
+    return result;
+  }
+
+ private:
+  struct Asset {
+    std::vector<std::uint32_t> chunks;
+    std::size_t byteSize = 0;
+    std::uint32_t refCount = 0;
+  };
+
+  std::byte* chunkData(std::uint32_t chunk) {
+    return region_.data() + static_cast<std::size_t>(chunk) * chunkBytes_;
+  }
+
+  const std::byte* chunkData(std::uint32_t chunk) const {
+    return region_.data() + static_cast<std::size_t>(chunk) * chunkBytes_;
+  }
+
+  std::size_t chunkBytes_ = 0;
+  std::size_t totalChunks_ = 0;
+  std::vector<std::byte> region_;
+  std::vector<std::uint32_t> freeList_;
+  std::unordered_map<AssetId, Asset> assets_;
+
+  std::size_t commits_ = 0;
+  std::size_t retains_ = 0;
+  std::size_t releases_ = 0;
+  std::size_t failedCommits_ = 0;
+};
+
+}  // namespace conway

--- a/conway_geometry/structures/tile_pool.h
+++ b/conway_geometry/structures/tile_pool.h
@@ -129,6 +129,13 @@ class TilePool {
     return true;
   }
 
+  /// One contiguous piece of a to-be-committed payload (iovec-style), so a
+  /// header + several vectors commit without first being concatenated.
+  struct PayloadPart {
+    const std::byte* data = nullptr;
+    std::size_t byteLength = 0;
+  };
+
   /// Make an asset resident with refCount 1 by scatter-copying `byteSize`
   /// bytes from `payload` into freshly acquired chunks. All-or-nothing:
   /// returns false (and changes nothing) if the free chunks can't cover it —
@@ -136,7 +143,23 @@ class TilePool {
   /// resident (use retainAsset first).
   bool commitAsset(AssetId asset, const std::byte* payload,
                    std::size_t byteSize) {
+    const PayloadPart part{payload, byteSize};
+    return commitAssetParts(asset, &part, 1);
+  }
+
+  /// As commitAsset, but the payload is the concatenation of `partCount`
+  /// discontiguous parts — the real tessellation-commit shape (a small
+  /// header plus the reified vertex and index vectors), copied straight
+  /// into chunks with no intermediate contiguous buffer.
+  bool commitAssetParts(AssetId asset, const PayloadPart* parts,
+                        std::size_t partCount) {
     assert(assets_.find(asset) == assets_.end());
+
+    std::size_t byteSize = 0;
+
+    for (std::size_t part = 0; part < partCount; ++part) {
+      byteSize += parts[part].byteLength;
+    }
 
     const std::size_t needed = (byteSize + chunkBytes_ - 1) / chunkBytes_;
 
@@ -150,18 +173,36 @@ class TilePool {
     entry.refCount = 1;
     entry.chunks.reserve(needed);
 
-    std::size_t copied = 0;
-
     for (std::size_t where = 0; where < needed; ++where) {
-      const std::uint32_t chunk = freeList_.back();
+      entry.chunks.push_back(freeList_.back());
       freeList_.pop_back();
-      entry.chunks.push_back(chunk);
+    }
 
-      const std::size_t span =
-          byteSize - copied < chunkBytes_ ? byteSize - copied : chunkBytes_;
+    // Walk parts and chunks together: fill each chunk from as many part
+    // spans as it takes, crossing part boundaries mid-chunk when needed.
+    std::size_t chunkIndex = 0;
+    std::size_t chunkFill = 0;
 
-      std::memcpy(chunkData(chunk), payload + copied, span);
-      copied += span;
+    for (std::size_t part = 0; part < partCount; ++part) {
+      const std::byte* source = parts[part].data;
+      std::size_t remaining = parts[part].byteLength;
+
+      while (remaining > 0) {
+        if (chunkFill == chunkBytes_) {
+          ++chunkIndex;
+          chunkFill = 0;
+        }
+
+        const std::size_t space = chunkBytes_ - chunkFill;
+        const std::size_t span = remaining < space ? remaining : space;
+
+        std::memcpy(chunkData(entry.chunks[chunkIndex]) + chunkFill, source,
+                    span);
+
+        source += span;
+        remaining -= span;
+        chunkFill += span;
+      }
     }
 
     assets_.emplace(asset, std::move(entry));

--- a/conway_geometry/structures/tile_pool_api.h
+++ b/conway_geometry/structures/tile_pool_api.h
@@ -135,8 +135,7 @@ inline bool tilePoolReadAsset(AssetId asset, std::byte* destination) {
     return false;
   }
 
-  pool->readAsset(asset, destination);
-  return true;
+  return pool->readAsset(asset, destination);
 }
 
 inline TilePool::Stats tilePoolStats() {

--- a/conway_geometry/structures/tile_pool_api.h
+++ b/conway_geometry/structures/tile_pool_api.h
@@ -1,0 +1,147 @@
+#pragma once
+
+/*
+ * Module-level surface over the resident TilePool (structures/tile_pool.h) —
+ * the seam the wasm bindings (conway-api.cpp) and, later, the tessellation
+ * commit path talk to. Free functions over one module-owned pool instance,
+ * mirroring the conway TS policy layer's expectations (bldrs-ai/conway
+ * src/core/mem/ + GeometryTilePool):
+ *
+ *   init once with the byte budget (paid exactly once — this is the region
+ *   the wasm heap grows by, deliberately, at open), then per asset:
+ *   retain-else-commit, release on evict, segment walk for GPU upload.
+ *
+ * Geometry tile payload layout (written by the conway-api.cpp glue from a
+ * reified Geometry; this header stays payload-agnostic):
+ *
+ *   u32 vertexByteLength   | 8-byte header, contiguous in the first chunk
+ *   u32 indexByteLength    | (init enforces chunkBytes >= 16)
+ *   float vertexData[..]     starting at byte offset 8
+ *   u32   indexData[..]      immediately after vertexData
+ *
+ * No emscripten dependencies — natively compilable alongside tile_pool.h.
+ */
+
+#include <cstdint>
+#include <memory>
+
+#include "tile_pool.h"
+
+namespace conway {
+
+inline constexpr std::size_t kTilePoolMinChunkBytes = 16;
+
+/// The module's pool. One per wasm instance, sized at open. unique_ptr so
+/// re-init (e.g. a new model with a different budget) releases the old
+/// region deterministically.
+inline std::unique_ptr<TilePool>& moduleTilePool() {
+  static std::unique_ptr<TilePool> pool;
+  return pool;
+}
+
+/// (Re)create the module pool. Any previous pool — and every tile in it —
+/// is dropped. Returns false on degenerate sizing.
+inline bool tilePoolInit(std::size_t budgetBytes, std::size_t chunkBytes) {
+  if (chunkBytes < kTilePoolMinChunkBytes || budgetBytes < chunkBytes) {
+    return false;
+  }
+
+  moduleTilePool() = std::make_unique<TilePool>(budgetBytes, chunkBytes);
+  return true;
+}
+
+inline bool tilePoolInitialized() { return moduleTilePool() != nullptr; }
+
+/// Commit a raw payload from module memory into freshly acquired chunks.
+/// All-or-nothing; false when absent pool, duplicate asset, or no room —
+/// the scheduler's cue to evict and retry.
+inline bool tilePoolCommitBytes(AssetId asset, const std::byte* payload,
+                                std::size_t byteLength) {
+  TilePool* pool = moduleTilePool().get();
+
+  if (pool == nullptr || pool->isResident(asset)) {
+    return false;
+  }
+
+  return pool->commitAsset(asset, payload, byteLength);
+}
+
+inline bool tilePoolRetain(AssetId asset) {
+  TilePool* pool = moduleTilePool().get();
+  return pool != nullptr && pool->retainAsset(asset);
+}
+
+/// Drop one reference; true when this was the last one (chunks returned).
+inline bool tilePoolRelease(AssetId asset) {
+  TilePool* pool = moduleTilePool().get();
+
+  if (pool == nullptr || !pool->isResident(asset)) {
+    return false;
+  }
+
+  return pool->releaseAsset(asset);
+}
+
+inline bool tilePoolIsResident(AssetId asset) {
+  TilePool* pool = moduleTilePool().get();
+  return pool != nullptr && pool->isResident(asset);
+}
+
+inline std::uint32_t tilePoolRefCount(AssetId asset) {
+  TilePool* pool = moduleTilePool().get();
+  return pool == nullptr ? 0 : pool->refCountOf(asset);
+}
+
+inline std::size_t tilePoolByteSize(AssetId asset) {
+  TilePool* pool = moduleTilePool().get();
+  return pool == nullptr ? 0 : pool->byteSizeOf(asset);
+}
+
+inline std::size_t tilePoolSegmentCount(AssetId asset) {
+  TilePool* pool = moduleTilePool().get();
+  return pool == nullptr ? 0 : pool->segmentCountOf(asset);
+}
+
+/// Pointer (as an address) + byte length of one payload segment, for the
+/// zero-copy per-segment GPU upload walk. 0 when absent / out of range.
+inline std::uintptr_t tilePoolSegmentAddress(AssetId asset,
+                                             std::size_t segment) {
+  TilePool* pool = moduleTilePool().get();
+
+  if (pool == nullptr || segment >= pool->segmentCountOf(asset)) {
+    return 0;
+  }
+
+  return reinterpret_cast<std::uintptr_t>(pool->segmentOf(asset, segment).first);
+}
+
+inline std::size_t tilePoolSegmentByteLength(AssetId asset,
+                                             std::size_t segment) {
+  TilePool* pool = moduleTilePool().get();
+
+  if (pool == nullptr || segment >= pool->segmentCountOf(asset)) {
+    return 0;
+  }
+
+  return pool->segmentOf(asset, segment).second;
+}
+
+/// Gather a tile's payload to contiguous module memory (the copying
+/// consumption path). Destination must hold tilePoolByteSize(asset).
+inline bool tilePoolReadAsset(AssetId asset, std::byte* destination) {
+  TilePool* pool = moduleTilePool().get();
+
+  if (pool == nullptr || !pool->isResident(asset)) {
+    return false;
+  }
+
+  pool->readAsset(asset, destination);
+  return true;
+}
+
+inline TilePool::Stats tilePoolStats() {
+  TilePool* pool = moduleTilePool().get();
+  return pool == nullptr ? TilePool::Stats{} : pool->stats();
+}
+
+}  // namespace conway

--- a/conway_geometry/structures/tile_pool_test.cpp
+++ b/conway_geometry/structures/tile_pool_test.cpp
@@ -164,6 +164,42 @@ void testAllOrNothingExhaustion() {
   check(pool.freeChunks() == 0, "full");
 }
 
+#ifdef NDEBUG
+// Release-build misuse hardening: caller bugs that assert in debug must be
+// safe no-ops in release — never a chunk leak (duplicate commit), never UB
+// (release/read/segment of a missing asset). Compiled only under NDEBUG so
+// the debug build's asserts stay loud.
+void testReleaseModeMisuseGuards() {
+  conway::TilePool pool(500, 100);
+
+  const auto payload = ramp(150, 5);
+  check(pool.commitAsset(1, payload.data(), payload.size()), "seed commit");
+
+  const std::size_t freeBefore = pool.freeChunks();
+
+  // Duplicate commit: refused, and crucially no chunks leak off the freelist.
+  check(!pool.commitAsset(1, payload.data(), payload.size()),
+        "duplicate commit refused");
+  check(pool.freeChunks() == freeBefore, "duplicate commit leaked no chunks");
+  check(pool.refCountOf(1) == 1, "duplicate commit did not bump refcount");
+
+  // Missing-asset operations: safe no-ops, not UB.
+  check(!pool.releaseAsset(999), "release of missing asset is a safe no-op");
+  check(pool.freeChunks() == freeBefore, "missing release changed nothing");
+
+  auto [ptr, len] = pool.segmentOf(999, 0);
+  check(ptr == nullptr && len == 0, "segmentOf missing asset yields null");
+
+  auto [ptr2, len2] = pool.segmentOf(1, 99);
+  check(ptr2 == nullptr && len2 == 0, "segmentOf out-of-range yields null");
+
+  std::vector<std::byte> out(150);
+  check(!pool.readAsset(999, out.data()), "read of missing asset refused");
+
+  check(pool.releaseAsset(1), "seed cleanly released");
+}
+#endif  // NDEBUG
+
 void testChurnStaysBounded() {
   conway::TilePool pool(500, 100);
 
@@ -197,6 +233,9 @@ int main() {
   testCommitReadRoundTrip();
   testInterleavedChunksStayCorrect();
   testMultiPartCommit();
+#ifdef NDEBUG
+  testReleaseModeMisuseGuards();
+#endif
   testRefcountSharing();
   testAllOrNothingExhaustion();
   testChurnStaysBounded();

--- a/conway_geometry/structures/tile_pool_test.cpp
+++ b/conway_geometry/structures/tile_pool_test.cpp
@@ -1,0 +1,175 @@
+// Standalone sanity test for the resident tile pool primitive
+// (structures/tile_pool.h). Builds with a plain host C++20 compiler — no
+// emsdk, no genie — so the invariants can be checked quickly while iterating:
+//
+//   c++ -std=c++20 -O2 -DCONWAY_TILE_POOL_STANDALONE_TEST -o /tmp/tp_test
+//       tile_pool_test.cpp  &&  /tmp/tp_test
+//
+// Exit 0 = all checks passed; non-zero = the first failed assertion.
+//
+// Guarded like scratch_arena_test.cpp so this file is an empty translation
+// unit in the normal build (the genie ConwayCoreFiles glob pulls in
+// conway_geometry/structures/**, and a stray main() would clash with the wasm
+// module entry).
+#ifdef CONWAY_TILE_POOL_STANDALONE_TEST
+
+#include "tile_pool.h"
+
+#include <cstdint>
+#include <cstdio>
+#include <vector>
+
+namespace {
+
+int g_failures = 0;
+
+void check(bool cond, const char* what) {
+  if (!cond) {
+    std::fprintf(stderr, "FAIL: %s\n", what);
+    ++g_failures;
+  }
+}
+
+std::vector<std::byte> ramp(std::size_t n, std::uint8_t seed) {
+  std::vector<std::byte> bytes(n);
+  for (std::size_t i = 0; i < n; ++i) {
+    bytes[i] = static_cast<std::byte>((seed + i) & 0xFF);
+  }
+  return bytes;
+}
+
+void testSizingAndRounding() {
+  conway::TilePool pool(1050, 100);
+  check(pool.totalChunks() == 10, "sizing: whole chunks from byte budget");
+  check(pool.totalBytes() == 1000, "sizing: totalBytes");
+  check(pool.chunkRound(250) == 300, "chunkRound rounds up");
+  check(pool.chunkRound(300) == 300, "chunkRound exact");
+  check(pool.bytesInUse() == 0, "empty pool has no use");
+}
+
+void testCommitReadRoundTrip() {
+  conway::TilePool pool(1000, 100);
+
+  // 250 bytes spans 3 chunks — the payload straddles chunk boundaries.
+  const auto payload = ramp(250, 7);
+  check(pool.commitAsset(1, payload.data(), payload.size()), "commit fits");
+  check(pool.bytesInUse() == 300, "physical use is chunk-rounded");
+  check(pool.byteSizeOf(1) == 250, "logical size preserved");
+  check(pool.segmentCountOf(1) == 3, "segment count");
+
+  std::vector<std::byte> out(250);
+  pool.readAsset(1, out.data());
+  check(out == payload, "gather read matches scatter commit");
+
+  // Per-segment view re-assembles to the same payload.
+  std::vector<std::byte> assembled;
+  for (std::size_t seg = 0; seg < pool.segmentCountOf(1); ++seg) {
+    auto [ptr, len] = pool.segmentOf(1, seg);
+    assembled.insert(assembled.end(), ptr, ptr + len);
+  }
+  check(assembled == payload, "segment walk matches payload");
+}
+
+void testInterleavedChunksStayCorrect() {
+  conway::TilePool pool(1000, 100);
+
+  // Fragment the freelist: commit A and B, free A, commit C — C's chunks
+  // interleave with B's. Data integrity must not depend on contiguity.
+  const auto a = ramp(300, 1);
+  const auto b = ramp(300, 2);
+  const auto c = ramp(450, 3);
+
+  check(pool.commitAsset(10, a.data(), a.size()), "commit A");
+  check(pool.commitAsset(11, b.data(), b.size()), "commit B");
+  check(pool.releaseAsset(10), "free A");
+  check(pool.commitAsset(12, c.data(), c.size()), "commit C into A's holes");
+
+  std::vector<std::byte> outB(300), outC(450);
+  pool.readAsset(11, outB.data());
+  pool.readAsset(12, outC.data());
+  check(outB == b, "B intact after interleave");
+  check(outC == c, "C correct across non-contiguous chunks");
+}
+
+void testRefcountSharing() {
+  conway::TilePool pool(1000, 100);
+
+  const auto payload = ramp(100, 9);
+  check(!pool.retainAsset(42), "retain of absent asset says commit needed");
+  check(pool.commitAsset(42, payload.data(), payload.size()), "commit");
+  check(pool.retainAsset(42), "second holder retains");
+  check(pool.refCountOf(42) == 2, "refcount 2");
+  check(pool.bytesInUse() == 100, "shared asset stored once");
+
+  check(!pool.releaseAsset(42), "first release keeps asset");
+  check(pool.isResident(42), "still resident for second holder");
+  check(pool.bytesInUse() == 100, "no premature free");
+
+  check(pool.releaseAsset(42), "last release frees");
+  check(!pool.isResident(42), "gone");
+  check(pool.bytesInUse() == 0, "chunks returned");
+}
+
+void testAllOrNothingExhaustion() {
+  conway::TilePool pool(300, 100);
+
+  const auto big = ramp(200, 1);
+  check(pool.commitAsset(1, big.data(), big.size()), "200 fits");
+
+  const auto tooBig = ramp(150, 2);
+  check(!pool.commitAsset(2, tooBig.data(), tooBig.size()),
+        "150 needs 2 chunks, 1 free: refused");
+  check(pool.freeChunks() == 1, "refusal changed nothing");
+  check(pool.stats().failedCommits == 1, "failure counted");
+
+  const auto exact = ramp(100, 3);
+  check(pool.commitAsset(3, exact.data(), exact.size()), "exact fit still ok");
+  check(pool.freeChunks() == 0, "full");
+}
+
+void testChurnStaysBounded() {
+  conway::TilePool pool(500, 100);
+
+  // 200 rounds of fill/evict: the region never grows and the high-water
+  // mark is the budget by construction.
+  for (int round = 0; round < 200; ++round) {
+    const auto a = ramp(300, static_cast<std::uint8_t>(round));
+    const auto b = ramp(200, static_cast<std::uint8_t>(round + 1));
+
+    check(pool.commitAsset(1, a.data(), a.size()), "churn commit A");
+    check(pool.commitAsset(2, b.data(), b.size()), "churn commit B");
+    check(pool.bytesInUse() == 500, "churn at budget");
+
+    std::vector<std::byte> out(300);
+    pool.readAsset(1, out.data());
+    check(out == a, "churn payload intact");
+
+    check(pool.releaseAsset(1), "churn free A");
+    check(pool.releaseAsset(2), "churn free B");
+    check(pool.bytesInUse() == 0, "churn drained");
+  }
+
+  check(pool.stats().commits == 400, "all commits counted");
+  check(pool.totalChunks() == 5, "pool never grew");
+}
+
+}  // namespace
+
+int main() {
+  testSizingAndRounding();
+  testCommitReadRoundTrip();
+  testInterleavedChunksStayCorrect();
+  testRefcountSharing();
+  testAllOrNothingExhaustion();
+  testChurnStaysBounded();
+
+  if (g_failures == 0) {
+    std::printf("tile_pool_test: all checks passed\n");
+    return 0;
+  }
+
+  std::fprintf(stderr, "tile_pool_test: %d failure(s)\n", g_failures);
+  return 1;
+}
+
+#endif  // CONWAY_TILE_POOL_STANDALONE_TEST

--- a/conway_geometry/structures/tile_pool_test.cpp
+++ b/conway_geometry/structures/tile_pool_test.cpp
@@ -91,6 +91,43 @@ void testInterleavedChunksStayCorrect() {
   check(outC == c, "C correct across non-contiguous chunks");
 }
 
+void testMultiPartCommit() {
+  conway::TilePool pool(1000, 100);
+
+  // Header + two "vectors", sized so parts cross chunk boundaries mid-part
+  // (8 + 250 + 121 = 379 bytes over 100-byte chunks).
+  const auto header = ramp(8, 100);
+  const auto vertices = ramp(250, 30);
+  const auto indices = ramp(121, 60);
+
+  const conway::TilePool::PayloadPart parts[3] = {
+      {header.data(), header.size()},
+      {vertices.data(), vertices.size()},
+      {indices.data(), indices.size()},
+  };
+
+  check(pool.commitAssetParts(77, parts, 3), "multi-part commit fits");
+  check(pool.byteSizeOf(77) == 379, "multi-part logical size");
+  check(pool.segmentCountOf(77) == 4, "multi-part segment count");
+
+  // Gather-read equals the concatenation of the parts.
+  std::vector<std::byte> expected;
+  expected.insert(expected.end(), header.begin(), header.end());
+  expected.insert(expected.end(), vertices.begin(), vertices.end());
+  expected.insert(expected.end(), indices.begin(), indices.end());
+
+  std::vector<std::byte> out(379);
+  pool.readAsset(77, out.data());
+  check(out == expected, "multi-part gather equals concatenated payload");
+
+  // And the single-part path still matches (delegates to parts).
+  check(pool.commitAsset(78, expected.data(), expected.size()),
+        "single-part commit of same payload");
+  std::vector<std::byte> out2(379);
+  pool.readAsset(78, out2.data());
+  check(out2 == expected, "single-part path unchanged");
+}
+
 void testRefcountSharing() {
   conway::TilePool pool(1000, 100);
 
@@ -159,6 +196,7 @@ int main() {
   testSizingAndRounding();
   testCommitReadRoundTrip();
   testInterleavedChunksStayCorrect();
+  testMultiPartCommit();
   testRefcountSharing();
   testAllOrNothingExhaustion();
   testChurnStaysBounded();

--- a/test/tile_pool_wasm_check.mjs
+++ b/test/tile_pool_wasm_check.mjs
@@ -1,0 +1,160 @@
+/**
+ * End-to-end check of the geometry tile pool through the REAL wasm build
+ * (Phase A of the demand-geometry track): initialise the pool inside the
+ * module, commit payloads from module memory, walk segments via the heap,
+ * and verify bytes, refcounts, budget accounting and the header readers —
+ * everything conway's InstanceAssetSource (Phase B) will sit on.
+ *
+ * Usage: node scripts/tile_pool_wasm_check.mjs
+ * Exit 0 = all checks passed.
+ */
+import { createRequire } from 'node:module'
+
+const require = createRequire( import.meta.url )
+
+let failures = 0
+
+function check( cond, what ) {
+  if ( !cond ) {
+    console.error( `FAIL: ${what}` )
+    ++failures
+  }
+}
+
+const loaded = require( '../Dist/ConwayGeomWasmNode.js' )
+const factory = typeof loaded === 'function' ? loaded : loaded.default
+const module_ = await factory()
+
+const CHUNK = 4096
+const BUDGET = 1024 * 1024 // 256 chunks
+
+// --- init ------------------------------------------------------------------
+check( !module_.geometryTilePoolInitialized(), 'pool starts uninitialised' )
+check( !module_.initGeometryTilePool( 100, 8 ), 'rejects chunk below floor' )
+check( module_.initGeometryTilePool( BUDGET, CHUNK ), 'init accepts budget' )
+check( module_.geometryTilePoolInitialized(), 'initialised after init' )
+check( module_.geometryTilePoolTotalBytes() === BUDGET, 'totalBytes = budget' )
+check( module_.geometryTilePoolBytesInUse() === 0, 'starts empty' )
+
+// --- commit raw payload from module memory ---------------------------------
+// A 10 000-byte ramp: spans 3 chunks, tail partially filling the last.
+const PAYLOAD = 10_000
+const source = module_._malloc( PAYLOAD )
+const heap = () => module_.HEAPU8
+
+for ( let i = 0; i < PAYLOAD; ++i ) {
+  heap()[ source + i ] = ( i * 7 ) & 0xFF
+}
+
+check( module_.commitGeometryTileBytes( 42, source, PAYLOAD ), 'commit fits' )
+check( module_.geometryTileResident( 42 ), 'resident after commit' )
+check( module_.geometryTileByteSize( 42 ) === PAYLOAD, 'logical size kept' )
+check( module_.geometryTilePoolBytesInUse() === 3 * CHUNK,
+    'physical use chunk-rounded' )
+
+// Scribble over the source then free it — the tile must hold its own copy.
+for ( let i = 0; i < PAYLOAD; ++i ) {
+  heap()[ source + i ] = 0
+}
+module_._free( source )
+
+// --- segment walk (the GPU-upload path) ------------------------------------
+const segments = module_.geometryTileSegmentCount( 42 )
+check( segments === 3, `3 segments (got ${segments})` )
+
+let offset = 0
+let intact = true
+
+for ( let segment = 0; segment < segments; ++segment ) {
+  const address = module_.geometryTileSegmentAddress( 42, segment )
+  const length = module_.geometryTileSegmentByteLength( 42, segment )
+  check( address > 0, `segment ${segment} address` )
+
+  const view = heap().subarray( address, address + length )
+
+  for ( let i = 0; i < length; ++i ) {
+    if ( view[ i ] !== ( ( ( offset + i ) * 7 ) & 0xFF ) ) {
+      intact = false
+      break
+    }
+  }
+  offset += length
+}
+
+check( offset === PAYLOAD, 'segments cover the payload exactly' )
+check( intact, 'payload bytes intact across segments (own copy)' )
+
+// --- refcount sharing ------------------------------------------------------
+check( module_.retainGeometryTile( 42 ), 'retain resident tile' )
+check( module_.geometryTileRefCount( 42 ) === 2, 'refcount 2' )
+check( !module_.releaseGeometryTile( 42 ), 'first release keeps tile' )
+check( module_.geometryTileResident( 42 ), 'still resident' )
+check( module_.releaseGeometryTile( 42 ), 'last release frees' )
+check( !module_.geometryTileResident( 42 ), 'gone after last release' )
+check( module_.geometryTilePoolBytesInUse() === 0, 'chunks returned' )
+
+// --- geometry-shaped payload + header readers ------------------------------
+// Simulate the reified layout via raw commit: [u32 vb][u32 ib][floats][u32s].
+const VERTEX_BYTES = 9 * 4 // 3 vertices x xyz floats
+const INDEX_BYTES = 3 * 4  // one triangle
+const total = 8 + VERTEX_BYTES + INDEX_BYTES
+const geometryPayload = module_._malloc( total )
+
+{
+  const view = new DataView( module_.HEAPU8.buffer, geometryPayload, total )
+  view.setUint32( 0, VERTEX_BYTES, true )
+  view.setUint32( 4, INDEX_BYTES, true )
+
+  const floats = [ 0, 0, 0, 1, 0, 0, 0, 1, 0 ]
+  floats.forEach( ( v, i ) => view.setFloat32( 8 + i * 4, v, true ) );
+  [ 0, 1, 2 ].forEach( ( v, i ) =>
+    view.setUint32( 8 + VERTEX_BYTES + i * 4, v, true ) )
+}
+
+check( module_.commitGeometryTileBytes( 7, geometryPayload, total ),
+    'geometry-shaped commit' )
+module_._free( geometryPayload )
+
+check( module_.geometryTileVertexByteLength( 7 ) === VERTEX_BYTES,
+    'header vertex byte length' )
+check( module_.geometryTileIndexByteLength( 7 ) === INDEX_BYTES,
+    'header index byte length' )
+
+// --- budget refusal + accounting -------------------------------------------
+const big = module_._malloc( CHUNK )
+let committed = 0
+
+// Fill the pool with 1-chunk tiles until refusal.
+for ( let id = 1000; id < 2000; ++id ) {
+  if ( !module_.commitGeometryTileBytes( id, big, CHUNK ) ) {
+    break
+  }
+  ++committed
+}
+module_._free( big )
+
+// 256-chunk budget minus tile 7's single chunk.
+check( committed === 255, `fills to budget (${committed} of 255)` )
+check( module_.geometryTilePoolFreeChunks() === 0, 'no free chunks at cap' )
+check( module_.geometryTilePoolFailedCommits() >= 1, 'refusal counted' )
+check( module_.geometryTilePoolBytesInUse() === BUDGET, 'bytesInUse = budget' )
+
+// Release everything; pool drains to zero (no leak, no growth).
+check( module_.releaseGeometryTile( 7 ), 'release geometry tile' )
+for ( let id = 1000; id < 1000 + committed; ++id ) {
+  check( module_.releaseGeometryTile( id ), `release ${id}` )
+}
+check( module_.geometryTilePoolBytesInUse() === 0, 'drained to zero' )
+check( module_.geometryTilePoolFreeChunks() === BUDGET / CHUNK, 'all chunks free' )
+
+// --- re-init drops everything ---------------------------------------------
+module_.commitGeometryTileBytes( 5, 0, 0 )
+check( module_.initGeometryTilePool( BUDGET, CHUNK ), 're-init ok' )
+check( !module_.geometryTileResident( 5 ), 're-init dropped tiles' )
+
+if ( failures === 0 ) {
+  console.log( 'tile_pool_wasm_check: all checks passed' )
+  process.exit( 0 )
+}
+console.error( `tile_pool_wasm_check: ${failures} failure(s)` )
+process.exit( 1 )


### PR DESCRIPTION
The wasm half of the demand-driven geometry residency design — companion to the conway streaming stack (all merged: bldrs-ai/conway #401–#405, #408, #409) and the *"Resident memory: two regimes"* design section. Epic bldrs-ai/conway#390. Three commits: the pool primitive, Phase A (the wasm boundary), and review hardening.

## Why

Wasm linear memory grows and never shrinks: `free()` returns bytes to mimalloc's freelists, not the browser, and wasm has no page decommit. So per-asset malloc/free can't return evicted geometry to the tab, and evict/refill churn turns fragmentation into a permanent high-water leak. The demand-geometry scheduler needs residents in memory it can *actually* reclaim and reuse — an explicit pool, not the general heap.

## Commit 1 — `TilePool` (`conway_geometry/structures/tile_pool.h`)

Header-only, std-only, `scratch_arena.h` conventions. **One region allocated exactly once** (the byte budget — the single deliberate wasm-heap growth, paid at open), fixed-size chunks + freelist: high-water mark = budget **by construction**, fragmentation reduced to bounded internal waste. **Refcounted assets** (instance ⇄ asset / occurrence ⇄ definition): storage keyed on the asset, chunks return on the **last** release only — evicting one product can never free a representation another still renders. Scheduling/budgets stay TS-side (conway `src/core/mem/`, accounting mirrored chunk-for-chunk); scratch stays on `ScratchArena` untouched.

## Commit 2 — Phase A: the wasm boundary

- **`commitAssetParts`** — iovec-style commit of discontiguous parts (header + reified vertex/index vectors) scatter-copied straight into chunks, no intermediate buffer.
- **`tile_pool_api.h`** — module-level surface (emscripten-free, natively compilable): init / retain-else-commit / release / segment walk / gather read / stats; documents the geometry-tile payload layout (`[u32 vertexBytes][u32 indexBytes][floats][u32 indices]`, header contiguous via a 16-byte chunk floor).
- **embind functions** — `initGeometryTilePool`; **`commitGeometryTile(assetId, Geometry&)`** committing the *reified* payload so the fat working `Geometry` can drop after commit; `commitGeometryTileBytes`; retain/release/resident/refCount/byteSize; `geometryTileSegmentAddress`/`ByteLength` (zero-copy per-segment GPU upload walk); header readers; pool counters.

## Commit 3 — review hardening (`cb71a31`)

**Chain-review finding**: the misuse guards were **assert-only**, and release builds (emscripten sets `NDEBUG`) compile asserts out — so in production wasm a duplicate `commitAssetParts` would **silently leak the freshly-acquired chunks** (map `emplace` no-ops on an existing key), and `releaseAsset` / `readAsset` / `segmentOf` on a missing asset dereferenced an end iterator (**UB**). The JS binding layer happened to guard these, but Phase B's *direct C++ callers* (the tessellation commit path) would not have been protected.

All four now keep the debug assert (loud in development) **and** a runtime guard for release: duplicate commit → `false`, no state change; missing-asset release/read → `false`; `segmentOf` → `{nullptr, 0}`. `readAsset` returns `bool` (api layer updated). The native test gained an **NDEBUG-only misuse suite** (duplicate commit provably leaks zero chunks off the freelist; missing-asset ops are safe no-ops) and is now compiled and run in **both modes** — which itself caught a missing `return` in the hardened `readAsset` before it shipped. Two-mode testing is now the file's documented workflow.

## Verification (no CI needed)

- **Native standalone test**, both modes: `-Wall -Wextra` clean, all checks passed under debug *and* `-DNDEBUG` (sizing/rounding; scatter/gather round-trip; interleaved non-contiguous chunk integrity; multi-part commit incl. mid-chunk part boundaries; misuse guards; refcount sharing; all-or-nothing exhaustion; 200-round churn with zero region growth). Empty-TU compile verified for the genie build.
- **Real wasm build + end-to-end check**, re-run after hardening: `ConwayGeomWasmNode` built clean with emsdk; `test/tile_pool_wasm_check.mjs` green through the actual module (init floor/budget, commit-from-module-memory with source scribbled-and-freed, byte-verified 3-segment walk, refcount share/release, header readers, fill-to-budget refusal accounting, drain-to-zero, re-init drop).

## Review status

Chain review 2026-07-20: one finding (assert-only guards, above), fixed in `cb71a31` and re-verified natively (both modes) and end-to-end through a fresh wasm build. Noted, not changed: `GetVertexData`/`GetIndexData`/size calls each invoke `Reify` — assumed cached-after-first (the existing GLB export path relies on the same pattern); worth a glance during Phase B wiring. `commitGeometryTile` header fields are u32 (4 GB per-tile cap) — tiles are bounded by the pool budget, far below.

## Not in this PR (Phase B/C, tracked in conway)

Tessellation pipeline calling `commitGeometryTile` at commit time; conway's `InstanceAssetSource` over these bindings; the async residency pump; Share upload/dispose wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S6gTXmrq1GbhqknPqQMRuz