### PR TITLE
STEP small-model fidelity: circle trims, CDT TryResolve, scale-relative deflection

### DIFF
--- a/conway_geometry/ConwayGeometryProcessor.cpp
+++ b/conway_geometry/ConwayGeometryProcessor.cpp
@@ -2711,12 +2711,18 @@ conway::geometry::IfcCurve ConwayGeometryProcessor::getAP214Circle(
       }
 
     } else  {
-      
+
+      // sense disagreement: sweep from trim1 to trim2 with DECREASING
+      // parameter, i.e. a negative length (the sampling loop below walks
+      // `startRad + ratio * lengthRad`, so a negative length lands exactly
+      // on trim2). This used to negate back to a positive sweep, which
+      // walked the complement arc CCW from trim1 and finished ~360deg away
+      // from trim2 — the final Add3d(trim2) then stitched a chord across
+      // the curve. The trim1 == trim2 full-circle case above stays correct
+      // (start - 360 remains -360: one full CW revolution).
       if ( lengthDegrees > 0.0) {
         lengthDegrees -= 360.0;
       }
-
-      lengthDegrees = -lengthDegrees;
     }
   }
 
@@ -2727,9 +2733,38 @@ conway::geometry::IfcCurve ConwayGeometryProcessor::getAP214Circle(
 
   size_t startIndex = curve.points.size();
 
-  for (int i = startOffset; i < ( CIRCLE_SEGMENTS_MEDIUM + endOffset ); i++)
-  { 
-    double ratio = static_cast<double>(i) / (CIRCLE_SEGMENTS_MEDIUM - 1);
+  // Adapt the sample count to the swept arc length so micro-arcs (CAD
+  // fillet slivers exported as fractions of a millimetre) don't emit a
+  // fixed 23 interior points. Those samples land closer together than
+  // ~100x the 2^-24 Add3d quantisation grid, and the quantisation wobble
+  // on such short constraint segments is what produced the CDT
+  // "Intersecting constraint edges" failures on otherwise-valid faces
+  // (Onshape AmazingHand Right_Hand.step). The chord floor is expressed
+  // in multiples of the quantum so it tracks the *actual* hazard —
+  // quantisation noise — independent of the file's length unit. Arcs
+  // longer than CIRCLE_SEGMENTS_MEDIUM chords keep the legacy fixed
+  // density (bit-identical output for typical models).
+  constexpr double LOOP_POINT_QUANTUM = 0x1p-24;
+  constexpr double MIN_SAMPLE_CHORD   = 256.0 * LOOP_POINT_QUANTUM;
+
+  double arcLength =
+      std::abs( degreesToRadians( lengthDegrees ) ) *
+      std::max( std::abs( radius1 ), std::abs( radius2 ) );
+
+  // Trimmed arcs may collapse to their chord (endpoints are appended
+  // exactly); an untrimmed full circle needs enough samples to stay a
+  // ring, so keep the LOW floor there.
+  int minimumSegments =
+      parameters.paramsGetIfcTrimmedCurve.trimExists ? 2 : CIRCLE_SEGMENTS_LOW;
+
+  int segments = std::clamp(
+      static_cast< int >( std::ceil( arcLength / MIN_SAMPLE_CHORD ) ),
+      minimumSegments,
+      CIRCLE_SEGMENTS_MEDIUM );
+
+  for (int i = startOffset; i < ( segments + endOffset ); i++)
+  {
+    double ratio = static_cast<double>(i) / (segments - 1);
     double angle = startRad + ratio * lengthRad;
 
     if (parameters.dimensions == 2)

--- a/conway_geometry/operations/curve_utils.h
+++ b/conway_geometry/operations/curve_utils.h
@@ -14,9 +14,45 @@
 namespace conway::geometry {
 
 constexpr double MIN_T_DELTA = 0.01;
-constexpr double MAX_CURVE_DEFLECTION = 0.001;
-constexpr double MAX_CURVE_DEFLECTION2 =
-    MAX_CURVE_DEFLECTION * MAX_CURVE_DEFLECTION;
+
+/**
+ * Squared chord-deviation threshold for adaptive B-spline curve sampling,
+ * relative to the curve's control hull extent (0.1% of its bounding-box
+ * diagonal). The old absolute MAX_CURVE_DEFLECTION (1mm linear) silently
+ * assumed millimetre-ish numeric scale: metre-unit STEP files (Onshape
+ * AP242 exports) stopped subdividing fingertip-sized silhouette edges at
+ * 1mm true deviation — visible faceting on the AmazingHand distal shells —
+ * matching the surface-side fix in tesselation_utils'
+ * relativeDeflectionSquared. The floor is the 2^-24 loop-point
+ * quantisation grid of IfcCurve::Add3d, below which a chord target is
+ * meaningless; it also guards degenerate zero-extent hulls.
+ *
+ * @param controlPoints The curve's control points (their hull bounds the
+ *   curve).
+ * @return The squared deflection threshold for the subdivision loop.
+ */
+template< typename PointType >
+inline double relativeCurveDeflectionSquared(
+    const std::vector< PointType >& controlPoints ) {
+
+  PointType boxMin( std::numeric_limits< double >::max() );
+  PointType boxMax( std::numeric_limits< double >::lowest() );
+
+  for ( const PointType& point : controlPoints ) {
+    boxMin = glm::min( boxMin, point );
+    boxMax = glm::max( boxMax, point );
+  }
+
+  constexpr double RELATIVE_DEFLECTION_FACTOR = 1e-3;
+  constexpr double MIN_DEFLECTION             = 0x1p-24;
+
+  double deflection =
+    controlPoints.empty() ?
+      0.0 :
+      glm::distance( boxMin, boxMax ) * RELATIVE_DEFLECTION_FACTOR;
+
+  return std::max( MIN_DEFLECTION * MIN_DEFLECTION, deflection * deflection );
+}
 
 inline bool isConvexOrColinear(glm::dvec2 a, glm::dvec2 b, glm::dvec2 c) {
   return (b.x - a.x) * (c.y - a.y) - (b.y - a.y) * (c.x - a.x) >= 0;
@@ -396,6 +432,8 @@ inline std::vector<glm::dvec3> GetRationalBSplineCurveWithKnots(
 
   std::vector<std::pair<double, glm::dvec3> > spanStack;
 
+  double maxDeflection2 = relativeCurveDeflectionSquared( points );
+
   double acceptedT = 0;
 
   result.push_back(InterpolateRationalBSplineCurveWithKnots(tStart, degree, points,
@@ -420,7 +458,7 @@ inline std::vector<glm::dvec3> GetRationalBSplineCurveWithKnots(
     glm::dvec3 deflectionVector = midPointSpline - midPointLinear;
 
     if ( fabs( deltaT ) > MIN_T_DELTA &&
-        glm::dot(deflectionVector, deflectionVector) > MAX_CURVE_DEFLECTION2 ) {
+        glm::dot(deflectionVector, deflectionVector) > maxDeflection2 ) {
       spanStack.emplace_back(candidateT, midPointSpline);
 
     } else {
@@ -440,6 +478,8 @@ inline std::vector<glm::dvec2> GetRationalBSplineCurveWithKnots(
   std::vector<glm::dvec2> result;
 
   std::vector<std::pair<double, glm::dvec2> > spanStack;
+
+  double maxDeflection2 = relativeCurveDeflectionSquared( points );
 
   double acceptedT = 0;
 
@@ -465,7 +505,7 @@ inline std::vector<glm::dvec2> GetRationalBSplineCurveWithKnots(
     glm::dvec2 deflectionVector = midPointSpline - midPointLinear;
 
     if ( fabs( deltaT ) > MIN_T_DELTA &&
-        glm::dot(deflectionVector, deflectionVector) > MAX_CURVE_DEFLECTION2) {
+        glm::dot(deflectionVector, deflectionVector) > maxDeflection2) {
       spanStack.emplace_back(candidateT, midPointSpline);
 
     } else {

--- a/conway_geometry/operations/manifold_utils.h
+++ b/conway_geometry/operations/manifold_utils.h
@@ -299,9 +299,17 @@ namespace conway::geometry
       }
     }
 
+    // TryResolve (here and at the other face-tessellation CDT sites in this
+    // file and mesh_utils.h): split intersecting constraints at their
+    // crossing instead of throwing — the throw dropped the whole face,
+    // leaving a hole in the mesh. Real CAD input reaches this with
+    // near-degenerate sliver boundaries (Onshape AmazingHand
+    // Right_Hand.step); a locally-imperfect triangulation beats a missing
+    // face. The csg_mesher sites deliberately keep NotAllowed: the boolean
+    // pipeline relies on exact constraint topology.
     CDT::Triangulation< double > triangulation(
       CDT::VertexInsertionOrder::AsProvided,
-      CDT::IntersectingConstraintEdges::NotAllowed, 0);
+      CDT::IntersectingConstraintEdges::TryResolve, 0);
 
     try
     {
@@ -733,7 +741,7 @@ namespace conway::geometry
 
     CDT::Triangulation< double > triangulation(
       CDT::VertexInsertionOrder::Auto,
-      CDT::IntersectingConstraintEdges::NotAllowed, 0);
+      CDT::IntersectingConstraintEdges::TryResolve, 0);
 
     try
     {
@@ -1107,7 +1115,7 @@ namespace conway::geometry
 
       CDT::Triangulation< double > triangulation(
         CDT::VertexInsertionOrder::AsProvided,
-        CDT::IntersectingConstraintEdges::NotAllowed,
+        CDT::IntersectingConstraintEdges::TryResolve,
         0);
 
       try

--- a/conway_geometry/operations/manifold_utils.h
+++ b/conway_geometry/operations/manifold_utils.h
@@ -349,6 +349,15 @@ namespace conway::geometry
         continue;
       }
 
+      // TryResolve can add split vertices past the input set; they have no world-space lift here, so skip the sliver triangles that touch them.
+      if (
+        cdtv1 >= vertexRemapping.size() ||
+        cdtv2 >= vertexRemapping.size() ||
+        cdtv3 >= vertexRemapping.size() )
+      {
+        continue;
+      }
+
       uint32_t v1 = vertexRemapping[ cdtv1 ];
       uint32_t v2 = vertexRemapping[ cdtv2 ];
       uint32_t v3 = vertexRemapping[ cdtv3 ];
@@ -785,6 +794,15 @@ namespace conway::geometry
         continue;
       }
 
+      // TryResolve can add split vertices past the input set; they have no world-space lift here, so skip the sliver triangles that touch them.
+      if (
+        cdtv1 >= vertexRemapping.size() ||
+        cdtv2 >= vertexRemapping.size() ||
+        cdtv3 >= vertexRemapping.size() )
+      {
+        continue;
+      }
+
       uint32_t v1 = vertexRemapping[ cdtv1 ];
       uint32_t v2 = vertexRemapping[ cdtv2 ];
       uint32_t v3 = vertexRemapping[ cdtv3 ];
@@ -1138,6 +1156,15 @@ namespace conway::geometry
         auto [ v1, v2, v3 ] = triangle.vertices;
 
         if ( v1 == v2 || v2 == v3 || v3 == v1 )
+        {
+          continue;
+        }
+
+        // TryResolve can add split vertices past the input set; they have no world-space lift here, so skip the sliver triangles that touch them.
+        if (
+          v1 >= reverseVertexRemapping.size() ||
+          v2 >= reverseVertexRemapping.size() ||
+          v3 >= reverseVertexRemapping.size() )
         {
           continue;
         }

--- a/conway_geometry/operations/manifold_utils.h
+++ b/conway_geometry/operations/manifold_utils.h
@@ -1160,18 +1160,24 @@ namespace conway::geometry
           continue;
         }
 
-        // TryResolve can add split vertices past the input set; they have no world-space lift here, so skip the sliver triangles that touch them.
+        // TryResolve can add split vertices past the input set; they have no
+        // world-space lift here, so skip the sliver triangles that touch them.
+        // vertexRemapping is CDT index -> mesh vertex, so its size is the CDT
+        // input count — the correct bound for that check. (This loop used to
+        // read reverseVertexRemapping[ cdt index ], which maps the OPPOSITE
+        // direction — mesh vertex -> CDT index, sized to the whole mesh — so
+        // every stitch triangle got scrambled or EMPTY_INDEX vertex ids.)
         if (
-          v1 >= reverseVertexRemapping.size() ||
-          v2 >= reverseVertexRemapping.size() ||
-          v3 >= reverseVertexRemapping.size() )
+          v1 >= vertexRemapping.size() ||
+          v2 >= vertexRemapping.size() ||
+          v3 >= vertexRemapping.size() )
         {
           continue;
         }
 
-        uint32_t outputV1 = reverseVertexRemapping[ v1 ];
-        uint32_t outputV2 = reverseVertexRemapping[ v2 ];
-        uint32_t outputV3 = reverseVertexRemapping[ v3 ];
+        uint32_t outputV1 = vertexRemapping[ v1 ];
+        uint32_t outputV2 = vertexRemapping[ v2 ];
+        uint32_t outputV3 = vertexRemapping[ v3 ];
 
         output.makeTriangle( outputV1, outputV2, outputV3 );
       }

--- a/conway_geometry/operations/mesh_utils.h
+++ b/conway_geometry/operations/mesh_utils.h
@@ -31,7 +31,6 @@
 
 namespace conway::geometry {
 
-constexpr double MAX_DEFLECTION            = 0.000001;
 constexpr double MAX_TRIANGLE_AMPLIFACTION = 32;
 
 
@@ -324,7 +323,7 @@ inline bool triangulateUnwrappedLoops(
 
   CDT::Triangulation< double > triangulation(
     CDT::VertexInsertionOrder::Auto,
-    CDT::IntersectingConstraintEdges::NotAllowed, 0 );
+    CDT::IntersectingConstraintEdges::TryResolve, 0 );
 
   try
   {
@@ -477,7 +476,7 @@ inline void TriangulateRevolution(Geometry &geometry,
       mesh,
       surfaceProjection,
       mesh.triangles.size() * MAX_TRIANGLE_AMPLIFACTION,
-      MAX_DEFLECTION );
+      relativeDeflectionSquared( mesh ) );
 
     appendMeshToGeometry( mesh, geometry );
   };
@@ -742,7 +741,7 @@ inline void TriangulateRevolution(Geometry &geometry,
 
           CDT::Triangulation< double > triangulation(
             CDT::VertexInsertionOrder::Auto,
-            CDT::IntersectingConstraintEdges::NotAllowed, 0 );
+            CDT::IntersectingConstraintEdges::TryResolve, 0 );
 
           bool triangulated = false;
 
@@ -1056,7 +1055,7 @@ inline void TriangulateSphericalSurface(Geometry &geometry,
       return glm::normalize( point - cent ) * radius + cent;
     },
     mesh.triangles.size() * MAX_TRIANGLE_AMPLIFACTION,
-    MAX_DEFLECTION );
+    relativeDeflectionSquared( mesh ) );
 
   appendMeshToGeometry( mesh, geometry );
 }
@@ -1647,7 +1646,7 @@ inline void TriangulateToroidalSurface(
 
       CDT::Triangulation< double > triangulation(
         CDT::VertexInsertionOrder::Auto,
-        CDT::IntersectingConstraintEdges::NotAllowed, 0);
+        CDT::IntersectingConstraintEdges::TryResolve, 0);
 
       bool logFailure = vertexCount == boundaryVertexCount;
 
@@ -1735,20 +1734,10 @@ inline void TriangulateToroidalSurface(
 
   // --- 6. Shared adaptive on-surface refinement -----------------------------
 
-  // Scale-aware refinement floor, as in the extrusion/cylinder unwraps: the
-  // absolute MAX_DEFLECTION is unreachable at model scale and reads as
+  // Scale-aware refinement threshold (relativeDeflectionSquared): the old
+  // absolute MAX_DEFLECTION was unreachable at large model scale and read as
   // "refine until the budget runs out" - tolerable when the budget was tiny
   // (boundary-only CDT), runaway now that interior seeding raises it.
-  glm::dvec3 boxMin( std::numeric_limits< double >::max() );
-  glm::dvec3 boxMax( std::numeric_limits< double >::lowest() );
-
-  for ( const glm::dvec3 &vertex : mesh.vertices ) {
-    boxMin = glm::min( boxMin, vertex );
-    boxMax = glm::max( boxMax, vertex );
-  }
-
-  double deflection = glm::distance( boxMin, boxMax ) * 1e-3;
-
   tesselate(
     mesh,
     [&]( const glm::dvec3& point ) {
@@ -1779,7 +1768,7 @@ inline void TriangulateToroidalSurface(
         vecZ * pointOnIdentityRing.z + cent;
     },
     mesh.triangles.size() * MAX_TRIANGLE_AMPLIFACTION,
-    std::max( MAX_DEFLECTION, deflection * deflection ) );
+    relativeDeflectionSquared( mesh ) );
 
   appendMeshToGeometry( mesh, geometry );
 }
@@ -1956,19 +1945,6 @@ inline void TriangulateConicalSurface(
 
       if ( triangulateUnwrappedLoops( loops, mesh, "cone" ) ) {
 
-        // Scale-aware refinement floor, as in the extrusion unwrap: the
-        // shared absolute MAX_DEFLECTION reads as "refine until the budget
-        // runs out" at large model scales.
-        glm::dvec3 boxMin( std::numeric_limits< double >::max() );
-        glm::dvec3 boxMax( std::numeric_limits< double >::lowest() );
-
-        for ( const glm::dvec3 &vertex : mesh.vertices ) {
-          boxMin = glm::min( boxMin, vertex );
-          boxMax = glm::max( boxMax, vertex );
-        }
-
-        double deflection = glm::distance( boxMin, boxMax ) * 1e-3;
-
         tesselate(
           mesh,
           [&]( const glm::dvec3 &point ) {
@@ -1993,7 +1969,7 @@ inline void TriangulateConicalSurface(
               vecZ * dz;
           },
           mesh.triangles.size() * MAX_TRIANGLE_AMPLIFACTION,
-          std::max( MAX_DEFLECTION, deflection * deflection ) );
+          relativeDeflectionSquared( mesh ) );
 
         appendMeshToGeometry( mesh, geometry );
         return;
@@ -2175,7 +2151,7 @@ inline void TriangulateConicalSurface(
       return cent + coneSpacePoint.x * vecX + coneSpacePoint.y * vecY + coneSpacePoint.z * vecZ;
     },
     mesh.triangles.size() * MAX_TRIANGLE_AMPLIFACTION,
-    MAX_DEFLECTION );
+    relativeDeflectionSquared( mesh ) );
 
   appendMeshToGeometry( mesh, geometry, sameSense );
 }
@@ -2208,9 +2184,9 @@ inline void TriangulateCylindricalSurface(Geometry &geometry,
   // axis, t the normalized axial coordinate - and CDT them with exact hole
   // nesting. The legacy path below earcuts an annulus projection whose
   // ring ordering assumes strict radial nesting by max-z; its chord
-  // triangles then get inflated by the budgeted refinement (the absolute
-  // MAX_DEFLECTION is unreachable at model scale) into lumpy off-surface
-  // shelves. Any degeneracy here falls back to that legacy path unchanged.
+  // triangles then get inflated by the budgeted refinement into lumpy
+  // off-surface shelves. Any degeneracy here falls back to that legacy
+  // path unchanged.
   {
     using namespace unwrap_detail;
 
@@ -2306,17 +2282,6 @@ inline void TriangulateCylindricalSurface(Geometry &geometry,
 
       if ( triangulateUnwrappedLoops( loops, unwrapMesh, "cylinder" ) ) {
 
-        // Scale-aware refinement floor, as in the extrusion unwrap.
-        glm::dvec3 boxMin( std::numeric_limits< double >::max() );
-        glm::dvec3 boxMax( std::numeric_limits< double >::lowest() );
-
-        for ( const glm::dvec3 &vertex : unwrapMesh.vertices ) {
-          boxMin = glm::min( boxMin, vertex );
-          boxMax = glm::max( boxMax, vertex );
-        }
-
-        double deflection = glm::distance( boxMin, boxMax ) * 1e-3;
-
         tesselate(
           unwrapMesh,
           [&]( const glm::dvec3 &point ) {
@@ -2338,7 +2303,7 @@ inline void TriangulateCylindricalSurface(Geometry &geometry,
               vecZ * dz;
           },
           unwrapMesh.triangles.size() * MAX_TRIANGLE_AMPLIFACTION,
-          std::max( MAX_DEFLECTION, deflection * deflection ) );
+          relativeDeflectionSquared( unwrapMesh ) );
 
         appendMeshToGeometry( unwrapMesh, geometry );
         return;
@@ -2523,7 +2488,7 @@ inline void TriangulateCylindricalSurface(Geometry &geometry,
       return cent + newInPlane.x * vecX + newInPlane.y * vecY + vecZ * dz;
     },
     mesh.triangles.size() * MAX_TRIANGLE_AMPLIFACTION,
-    MAX_DEFLECTION );
+    relativeDeflectionSquared( mesh ) );
 
   appendMeshToGeometry( mesh, geometry, sameSense );
 }
@@ -2640,30 +2605,20 @@ inline void TriangulateExtrusion(Geometry &geometry,
     return foot + axis * t;
   };
 
-  // Scale-aware refinement floor: stop subdividing once midpoint deviation
-  // drops below 0.1% of the face's extent (the same visual criterion as the
-  // revolution ring count). The shared absolute MAX_DEFLECTION reads as
-  // "refine until the budget runs out" at large model scales, and with
-  // 1,370 extrusion faces on the jet compressor alone that doubled the
-  // model's triangle count for invisible gains.
+  // Scale-aware refinement threshold (relativeDeflectionSquared): stop
+  // subdividing once midpoint deviation drops below 0.1% of the face's
+  // extent (the same visual criterion as the revolution ring count). The
+  // old shared absolute MAX_DEFLECTION read as "refine until the budget
+  // runs out" at large model scales, and with 1,370 extrusion faces on the
+  // jet compressor alone that doubled the model's triangle count for
+  // invisible gains.
   auto refineAndAppend = [&]( WingedEdgeMesh< glm::dvec3 > &mesh ) {
-
-    glm::dvec3 boxMin( std::numeric_limits< double >::max() );
-    glm::dvec3 boxMax( std::numeric_limits< double >::lowest() );
-
-    for ( const glm::dvec3 &vertex : mesh.vertices ) {
-      boxMin = glm::min( boxMin, vertex );
-      boxMax = glm::max( boxMax, vertex );
-    }
-
-    double diagonal   = glm::distance( boxMin, boxMax );
-    double deflection = diagonal * 1e-3;
 
     tesselate(
       mesh,
       surfaceProjection,
       mesh.triangles.size() * MAX_TRIANGLE_AMPLIFACTION,
-      std::max( MAX_DEFLECTION, deflection * deflection ) );
+      relativeDeflectionSquared( mesh ) );
 
     appendMeshToGeometry( mesh, geometry );
   };
@@ -2896,7 +2851,7 @@ inline void TriangulateExtrusion(Geometry &geometry,
 
   CDT::Triangulation< double > triangulation(
     CDT::VertexInsertionOrder::Auto,
-    CDT::IntersectingConstraintEdges::NotAllowed, 0 );
+    CDT::IntersectingConstraintEdges::TryResolve, 0 );
 
   try
   {
@@ -3341,7 +3296,7 @@ inline void TriangulateBspline(Geometry &geometry,
         return bSplineInverseEvaluation.evaluator.point( from.x, from.y );
       },
       mesh.triangles.size() * MAX_TRIANGLE_AMPLIFACTION,
-      MAX_DEFLECTION );
+      relativeDeflectionSquared( mesh ) );
 
     appendMeshToGeometry( mesh, geometry, !surface.sameSense );
 

--- a/conway_geometry/operations/mesh_utils.h
+++ b/conway_geometry/operations/mesh_utils.h
@@ -354,6 +354,14 @@ inline bool triangulateUnwrappedLoops(
       continue;
     }
 
+    // TryResolve can add split vertices past the input set; they have no world-space lift here, so skip the sliver triangles that touch them.
+    if (
+      cdtv1 >= cdtWorld.size() ||
+      cdtv2 >= cdtWorld.size() ||
+      cdtv3 >= cdtWorld.size() ) {
+      continue;
+    }
+
     mesh.makeTriangle( cdtv1, cdtv2, cdtv3 );
   }
 
@@ -776,6 +784,14 @@ inline void TriangulateRevolution(Geometry &geometry,
               auto [ cdtv1, cdtv2, cdtv3 ] = triangle.vertices;
 
               if ( cdtv1 == cdtv2 || cdtv2 == cdtv3 || cdtv3 == cdtv1 ) {
+                continue;
+              }
+
+              // TryResolve can add split vertices past the input set; they have no world-space lift here, so skip the sliver triangles that touch them.
+              if (
+                cdtv1 >= cdtWorld.size() ||
+                cdtv2 >= cdtWorld.size() ||
+                cdtv3 >= cdtWorld.size() ) {
                 continue;
               }
 
@@ -1714,6 +1730,14 @@ inline void TriangulateToroidalSurface(
       auto [ cdtv1, cdtv2, cdtv3 ] = triangle.vertices;
 
       if ( cdtv1 == cdtv2 || cdtv2 == cdtv3 || cdtv3 == cdtv1 ) {
+        continue;
+      }
+
+      // TryResolve can add split vertices past the input set; they have no world-space lift here, so skip the sliver triangles that touch them.
+      if (
+        cdtv1 >= usedVertexCount ||
+        cdtv2 >= usedVertexCount ||
+        cdtv3 >= usedVertexCount ) {
         continue;
       }
 
@@ -2882,6 +2906,14 @@ inline void TriangulateExtrusion(Geometry &geometry,
     auto [ cdtv1, cdtv2, cdtv3 ] = triangle.vertices;
 
     if ( cdtv1 == cdtv2 || cdtv2 == cdtv3 || cdtv3 == cdtv1 ) {
+      continue;
+    }
+
+    // TryResolve can add split vertices past the input set; they have no world-space lift here, so skip the sliver triangles that touch them.
+    if (
+      cdtv1 >= cdtWorld.size() ||
+      cdtv2 >= cdtWorld.size() ||
+      cdtv3 >= cdtWorld.size() ) {
       continue;
     }
 

--- a/conway_geometry/operations/tesselation_utils.h
+++ b/conway_geometry/operations/tesselation_utils.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cmath>
+#include <limits>
 #include <glm/glm.hpp>
 
 #include "structures/winged_edge.h"
@@ -37,8 +38,66 @@ namespace conway::geometry {
 
     glm::dvec3 point;
     glm::dvec2 uv;
-    
+
   };
+
+  /** Position accessors so bound computations span both mesh vertex types. */
+  inline const glm::dvec3& refinementPoint( const glm::dvec3& vertex ) {
+    return vertex;
+  }
+
+  /** Position of a UV parameterized vertex. */
+  inline const glm::dvec3& refinementPoint( const ParameterVertex& vertex ) {
+    return vertex.point;
+  }
+
+  /**
+   * Squared deflection threshold for `tesselate`, relative to the seed
+   * mesh's own extent — 0.1% of its bounding-box diagonal, squared to match
+   * the squared-deflection comparison in the refinement loop.
+   *
+   * Unit-independence is the point. The shared absolute MAX_DEFLECTION
+   * (1e-6, i.e. 1mm linear deflection) silently assumed millimetre-ish
+   * numeric scale: in metre-unit STEP files (Onshape AP242 exports) every
+   * curved face smaller than a metre bottomed out on the absolute constant
+   * and stopped refining at ~1mm true deflection — visibly faceted
+   * fingertip-sized B-spline/cylinder faces on the AmazingHand model —
+   * while in millimetre-unit files the same constant was so fine it read
+   * as "refine until the triangle budget runs out" (see the extrusion
+   * unwrap's jet-compressor note). The relative criterion follows the
+   * 0.1%-of-extent convention the revolution/extrusion/cylinder unwraps
+   * already used; the tiny floor (the 2^-24 loop-point quantisation grid
+   * of IfcCurve::Add3d, below which a deflection target is meaningless)
+   * only guards degenerate zero-extent seeds against refine-to-zero churn.
+   *
+   * @param mesh The seed mesh about to be refined.
+   * @return The squared deflection threshold to pass to `tesselate`.
+   */
+  template< typename VertexType >
+  inline double relativeDeflectionSquared(
+      const WingedEdgeMesh< VertexType >& mesh ) {
+
+    glm::dvec3 boxMin( std::numeric_limits< double >::max() );
+    glm::dvec3 boxMax( std::numeric_limits< double >::lowest() );
+
+    for ( const VertexType& vertex : mesh.vertices ) {
+
+      const glm::dvec3& point = refinementPoint( vertex );
+
+      boxMin = glm::min( boxMin, point );
+      boxMax = glm::max( boxMax, point );
+    }
+
+    constexpr double RELATIVE_DEFLECTION_FACTOR = 1e-3;
+    constexpr double MIN_DEFLECTION             = 0x1p-24;
+
+    double deflection =
+      mesh.vertices.empty() ?
+        0.0 :
+        glm::distance( boxMin, boxMax ) * RELATIVE_DEFLECTION_FACTOR;
+
+    return std::max( MIN_DEFLECTION * MIN_DEFLECTION, deflection * deflection );
+  }
 
   /**
    * Compute the normal of a parameter vertex.


### PR DESCRIPTION
## Summary

Brings the five geometry-kernel commits already shipping via conway#444's submodule pointer (`31c1296`) into conway-geom main, so the submodule tracks mainline history. Branch is based on the previously pinned `28d316a` (an ancestor of main) with no drift against main in the touched files — merges clean.

## Commits

1. **`getAP214Circle`: sense-disagreement sweep + adaptive arc sampling** — `senseAgreement=false` mis-negated the sweep back to positive (walked the complement arc from trim1 and chord-stitched to trim2); arc sample counts now scale with arc length under a quantiser-relative chord floor, eliminating micro-arc CDT "Intersecting constraint edges" failures at the source.
2. **CDT `TryResolve` at face-tessellation sites** — sliver-boundary faces triangulate instead of dropping to holes; csg_mesher sites deliberately keep `NotAllowed`.
3. **Extent-relative refinement deflection** — surfaces (`relativeDeflectionSquared`) and B-spline curves (`relativeCurveDeflectionSquared`) refine to 0.1% of feature extent instead of absolute constants that assumed millimetre numeric scale; consolidates the ad-hoc relative computations the revolution/extrusion/cylinder unwraps already carried.
4. **Guards against TryResolve-inserted split vertices** — resolve-split vertices index past the consumers' input vertex arrays; skip the sliver triangles that touch them (a proper fix would lift them through each site's inverse parameterization).
5. **Equator-stitch remap fix** — the dual-parameterization hole-fill consumed CDT triangles through `reverseVertexRemapping` (mesh→CDT) instead of `vertexRemapping` (CDT→mesh), scrambling stitch-triangle vertex ids; found while auditing the guards in review of conway#444.

## Verification

Validated through conway#444 (merged): smoke regression zero failures with 7 chronic CDT errors resolved (supercap ×5, driver board ×2), visual diffs reviewed (AmazingHand Right_Hand corrected from spike-explosion to proper geometry; supercap cap faces restored), conway jest suite 360/360 against a local emsdk 6.0.2 NodeMT build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhouF3Ly73rKNcpaBzztFo

---
_Generated by [Claude Code](https://claude.ai/code/session_01HhouF3Ly73rKNcpaBzztFo)_